### PR TITLE
refactor: update experience to use static data with detail pages

### DIFF
--- a/src/app/experience/[slug]/page.tsx
+++ b/src/app/experience/[slug]/page.tsx
@@ -1,0 +1,18 @@
+import ExperienceDetail from "@/features/front/experience/components/ExperienceDetail";
+import { sortedExperiences } from "@/data";
+
+const ExperiencePage = async (props: { params: Promise<{ slug: string }> }) => {
+	const params = await props.params;
+
+	return <ExperienceDetail slug={params.slug} />;
+};
+
+export default ExperiencePage;
+
+export const dynamic = "force-static";
+
+export async function generateStaticParams() {
+	return sortedExperiences.map((exp) => ({
+		slug: exp.slug,
+	}));
+}

--- a/src/features/front/experience/components/Experience.tsx
+++ b/src/features/front/experience/components/Experience.tsx
@@ -1,25 +1,9 @@
-import { getExperienceInfo } from "@/features/utils/actions";
-import { createClient } from "@/utils/supabase/server";
 import Link from "next/link";
-import { Job } from "@/types";
+import { sortedExperiences } from "@/data";
+import { ViewTransitionLink } from "@/components/ViewTransitionLink";
 
 const Experience = async () => {
-	const supabase = await createClient();
-
-	const data: Job[] = await getExperienceInfo({ supabase });
-
-	const sortJobsByStartDate = (jobs: Job[]): Job[] => {
-		return jobs.sort((a, b) => {
-			const parseDate = (dateStr: string) => {
-				const [month, year] = dateStr.trim().split("/").map(Number);
-				return new Date(year, month - 1).getTime(); // Convert to timestamp
-			};
-
-			return parseDate(b.startedAt) - parseDate(a.startedAt); // Descending order
-		});
-	};
-
-	const experience = sortJobsByStartDate(data);
+	const experience = sortedExperiences;
 
 	return (
 		<>
@@ -30,27 +14,34 @@ const Experience = async () => {
 			</div>
 			<div>
 				<ol className="group/list">
-					{experience.map((job, index) => (
+					{experience.map((exp, index) => (
 						<li key={index} className="mb-12">
 							<div className="group relative grid pb-1 transition-all sm:grid-cols-8 sm:gap-8 md:gap-4 lg:hover:!opacity-100 lg:group-hover/list:opacity-50">
 								<div className="absolute -inset-x-4 -inset-y-4 z-0 hidden rounded-md transition motion-reduce:transition-none lg:-inset-x-6 lg:block lg:group-hover:bg-slate-800/50 lg:group-hover:shadow-[inset_0_1px_0_0_rgba(148,163,184,0.1)] lg:group-hover:drop-shadow-lg"></div>
 								<header className="z-10 mb-2 mt-1 text-xs font-semibold uppercase tracking-wide text-slate-500 sm:col-span-2">
-									{job.startedAt} - {job.finishedAt}
+									{exp.startDate} - {exp.endDate}
 								</header>
 								<div className="z-10 sm:col-span-6">
 									<h3 className="font-medium leading-snug text-slate-200">
-										{job.position + ` · ` + job.company}
+										<ViewTransitionLink
+											href={`/experience/${exp.slug}`}
+											className="hover:text-sky-400 focus-visible:text-sky-400"
+										>
+											<span style={{ viewTransitionName: `exp-title-${exp.slug}` }}>
+												{exp.position} · {exp.company}
+											</span>
+										</ViewTransitionLink>
 									</h3>
 									<p className="mt-2 text-sm leading-normal">
-										{job.description}
+										{exp.description}
 									</p>
 									<ul className="mt-2 flex flex-wrap">
-										{job.techStack.map((skill, index) => (
+										{exp.technologies.map((skill, index) => (
 											<li
 												key={index}
 												className="mr-1.5 mt-2"
 											>
-												<div className="flex items-center rounded-full bg-teal-400/10 px-3 py-1 text-xs font-medium leading-5 text-teal-300 ">
+												<div className="flex items-center rounded-full bg-sky-400/10 px-3 py-1 text-xs font-medium leading-5 text-sky-400 ">
 													{skill}
 												</div>
 											</li>
@@ -61,14 +52,6 @@ const Experience = async () => {
 						</li>
 					))}
 				</ol>
-				<div className="mt-12">
-					<Link
-						href="/resume"
-						className="inline-flex items-baseline font-medium leading-tight text-slate-200 hover:text-teal-300 focus-visible:text-teal-300 group/link text-base"
-					>
-						View Full Resume
-					</Link>
-				</div>
 			</div>
 		</>
 	);

--- a/src/features/front/experience/components/ExperienceDetail.tsx
+++ b/src/features/front/experience/components/ExperienceDetail.tsx
@@ -1,0 +1,146 @@
+import { getExperienceBySlug, getAdjacentExperiences } from "@/data";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import Link from "next/link";
+import Image from "next/image";
+import { ViewTransitionLink } from "@/components/ViewTransitionLink";
+
+interface ExperienceDetailProps {
+	slug: string;
+}
+
+const ExperienceDetail = async ({ slug }: ExperienceDetailProps) => {
+	const experience = getExperienceBySlug(slug);
+
+	if (!experience) {
+		return (
+			<div className="mx-auto min-h-screen max-w-screen-xl px-6 py-12">
+				<p>Experience not found</p>
+			</div>
+		);
+	}
+
+	const { prev, next } = getAdjacentExperiences(slug);
+
+	return (
+		<div className="mx-auto min-h-screen max-w-screen-xl px-6 py-12 md:px-12 md:py-20 lg:px-24 lg:py-24">
+			{/* Back navigation */}
+			<ViewTransitionLink
+				href="/#experience"
+				className="group mb-8 inline-flex items-center font-semibold leading-tight text-sky-400"
+			>
+				<ArrowLeft className="mr-1 size-4 group-hover:-translate-x-2 transition-transform" />
+				Back to home
+			</ViewTransitionLink>
+
+			{/* Header section */}
+			<header className="mb-12">
+				{experience.logo && (
+					<div className="mb-6">
+						<Image
+							src={experience.logo}
+							alt={`${experience.company} logo`}
+							width={80}
+							height={80}
+							className="rounded-lg"
+						/>
+					</div>
+				)}
+				<h1
+					className="text-4xl font-bold tracking-tight text-slate-200 sm:text-5xl mb-2"
+					style={{ viewTransitionName: `exp-title-${experience.slug}` }}
+				>
+					{experience.position} · {experience.company}
+				</h1>
+				<p className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+					{experience.startDate} — {experience.endDate}
+				</p>
+			</header>
+
+			{/* Description */}
+			<section className="mb-12">
+				<p className="text-lg leading-relaxed text-slate-300">
+					{experience.description}
+				</p>
+			</section>
+
+			{/* Key Highlights */}
+			{experience.highlights.length > 0 && (
+				<section className="mb-12">
+					<h2 className="text-xl font-semibold text-sky-400 uppercase tracking-wide mb-4">
+						Key Highlights
+					</h2>
+					<ul className="space-y-3">
+						{experience.highlights.map((highlight, index) => (
+							<li
+								key={index}
+								className="flex items-start text-slate-300"
+							>
+								<span className="mr-3 mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-sky-400" />
+								{highlight}
+							</li>
+						))}
+					</ul>
+				</section>
+			)}
+
+			{/* Technologies */}
+			{experience.technologies.length > 0 && (
+				<section className="mb-12">
+					<h2 className="text-xl font-semibold text-sky-400 uppercase tracking-wide mb-4">
+						Technologies
+					</h2>
+					<ul className="flex flex-wrap gap-2">
+						{experience.technologies.map((tech, index) => (
+							<li
+								key={index}
+								className="flex items-center rounded-full bg-sky-400/10 px-3 py-1 text-sm font-medium leading-5 text-sky-400"
+							>
+								{tech}
+							</li>
+						))}
+					</ul>
+				</section>
+			)}
+
+			{/* Navigation between experiences */}
+			<nav className="mt-16 pt-8 border-t border-slate-300/10">
+				<div className="flex justify-between items-center">
+					{prev ? (
+						<ViewTransitionLink
+							href={`/experience/${prev.slug}`}
+							className="group flex items-center text-slate-400 hover:text-sky-400 transition-colors"
+						>
+							<ArrowLeft className="mr-2 size-4 group-hover:-translate-x-1 transition-transform" />
+							<div className="text-left">
+								<p className="text-xs uppercase tracking-wide text-slate-500">
+									Previous
+								</p>
+								<p className="font-medium">{prev.position}</p>
+							</div>
+						</ViewTransitionLink>
+					) : (
+						<div />
+					)}
+					{next ? (
+						<ViewTransitionLink
+							href={`/experience/${next.slug}`}
+							className="group flex items-center text-slate-400 hover:text-sky-400 transition-colors"
+						>
+							<div className="text-right">
+								<p className="text-xs uppercase tracking-wide text-slate-500">
+									Next
+								</p>
+								<p className="font-medium">{next.position}</p>
+							</div>
+							<ArrowRight className="ml-2 size-4 group-hover:translate-x-1 transition-transform" />
+						</ViewTransitionLink>
+					) : (
+						<div />
+					)}
+				</div>
+			</nav>
+		</div>
+	);
+};
+
+export default ExperienceDetail;

--- a/src/features/front/experience/components/ExperienceSkeleton.tsx
+++ b/src/features/front/experience/components/ExperienceSkeleton.tsx
@@ -20,17 +20,17 @@ const ExperienceCardSkeleton = () => {
 					</div>
 					<ul className="mt-2 flex flex-wrap">
 						<li className="mr-1.5 mt-2">
-							<div className="flex items-center rounded-full bg-teal-400/10 px-3 py-1 text-xs font-medium leading-5 text-teal-300 ">
+							<div className="flex items-center rounded-full bg-sky-400/10 px-3 py-1 text-xs font-medium leading-5 text-sky-400 ">
 								<Skeleton className="w-10 h-4" />
 							</div>
 						</li>
 						<li className="mr-1.5 mt-2">
-							<div className="flex items-center rounded-full bg-teal-400/10 px-3 py-1 text-xs font-medium leading-5 text-teal-300 ">
+							<div className="flex items-center rounded-full bg-sky-400/10 px-3 py-1 text-xs font-medium leading-5 text-sky-400 ">
 								<Skeleton className="w-10 h-4" />
 							</div>
 						</li>
 						<li className="mr-1.5 mt-2">
-							<div className="flex items-center rounded-full bg-teal-400/10 px-3 py-1 text-xs font-medium leading-5 text-teal-300 ">
+							<div className="flex items-center rounded-full bg-sky-400/10 px-3 py-1 text-xs font-medium leading-5 text-sky-400 ">
 								<Skeleton className="w-10 h-4" />
 							</div>
 						</li>


### PR DESCRIPTION
## Summary
- Migrate experience feature from Supabase to static data layer
- Add dedicated detail pages for each experience entry

## Changes Made
- Updated Experience.tsx to use static data imports and ViewTransitionLink
- Added clickable experience entries with view transition names
- Updated ExperienceSkeleton.tsx accent colors
- Removed "View Full Resume" link (resume page removed separately)
- Added ExperienceDetail.tsx component for detail pages
- Added new experience/[slug]/page.tsx with generateStaticParams for SSG

## Why These Changes?
Provides interactive experience detail pages with highlights and technologies, replacing the static resume PDF viewer.

## Type of Change
- [x] Refactoring

## Features
- Clickable experience entries from home page
- Structured detail pages with highlights and technologies
- Previous/next experience navigation
- View transitions between list and detail views

## Dependencies
- Depends on PR #2 (static data layer)
- Depends on PR #3 (view transitions)