### PR TITLE
refactor: remove Suspense components from static data

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,3 @@
-import { Suspense } from "react";
-
 import Header from "@/features/front/components/Header";
 import AboutMe from "@/features/front/about-me/components/AboutMe";
 import Experience from "@/features/front/experience/components/Experience";
@@ -7,8 +5,6 @@ import Projects from "@/features/front/projects/components/Projects";
 import MainContainerWrapper from "@/features/front/components/MainContainerWrapper";
 import Footer from "@/features/front/components/Footer";
 import { SectionWrapper } from "@/features/front/components/SectionWrapper";
-import ExperienceSkeleton from "@/features/front/experience/components/ExperienceSkeleton";
-import ProjectsSkeleton from "@/features/front/projects/components/ProjectsSkeleton";
 
 export default async function Page() {
 	return (
@@ -28,18 +24,14 @@ export default async function Page() {
 						styles="mb-16 scroll-mt-16 mdd:mb-24 lg:mb-36 lg:scroll-mt-24"
 						ariaLabel="Selected projects"
 					>
-						<Suspense fallback={<ProjectsSkeleton />}>
-							<Projects />
-						</Suspense>
+						<Projects />
 					</SectionWrapper>
 					<SectionWrapper
 						id="experience"
 						styles="mb-16 scroll-mt-16 md:mb-24 lg:mb-36 lg:scroll-mt-24"
 						ariaLabel="Work experience"
 					>
-						<Suspense fallback={<ExperienceSkeleton />}>
-							<Experience />
-						</Suspense>
+						<Experience />
 					</SectionWrapper>
 					<Footer />
 				</MainContainerWrapper>

--- a/src/features/front/experience/components/Experience.tsx
+++ b/src/features/front/experience/components/Experience.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { sortedExperiences } from "@/data";
 import { ViewTransitionLink } from "@/components/ViewTransitionLink";
 
-const Experience = async () => {
+const Experience = () => {
 	const experience = sortedExperiences;
 
 	return (

--- a/src/features/front/projects/components/Projects.tsx
+++ b/src/features/front/projects/components/Projects.tsx
@@ -4,7 +4,7 @@ import { ArrowRight } from "lucide-react";
 import { featuredProjects } from "@/data";
 import { ViewTransitionLink } from "@/components/ViewTransitionLink";
 
-const Projects = async () => {
+const Projects = () => {
 	const projects = featuredProjects;
 
 	return (

--- a/src/features/front/projects/components/SingleProject.tsx
+++ b/src/features/front/projects/components/SingleProject.tsx
@@ -1,10 +1,8 @@
 import { getProjectBySlug, getAdjacentProjects } from "@/data";
 import { ArrowLeft, ArrowRight, ExternalLink, Github } from "lucide-react";
-import { Suspense } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import BackButton from "./BackButton";
-import { Skeleton } from "@/components/ui/skeleton";
 import Zoom from "react-medium-image-zoom";
 import "react-medium-image-zoom/dist/styles.css";
 import { ViewTransitionLink } from "@/components/ViewTransitionLink";
@@ -68,20 +66,19 @@ const SingleProject = async ({ slug }: SingleProjectProps) => {
 
 			{/* Hero image */}
 			<section className="mb-16">
-				<Suspense fallback={<Skeleton className="h-80 w-full rounded-lg" />}>
-					<div style={{ viewTransitionName: `project-image-${project.slug}` }}>
-						<Zoom>
-							<Image
-								src={project.image}
-								alt={`Screenshot of ${project.title} showing the main interface and features`}
-								width={1200}
-								height={600}
-								className="h-auto w-full rounded-lg border border-slate-200/10"
-								priority
-							/>
-						</Zoom>
-					</div>
-				</Suspense>
+				<div style={{ viewTransitionName: `project-image-${project.slug}` }}>
+					<Zoom>
+						<Image
+							src={project.image}
+							alt={`Screenshot of ${project.title} showing the main interface and features`}
+							width={1200}
+							height={600}
+							className="h-auto w-full rounded-lg border border-slate-200/10"
+							priority
+							loading="eager"
+						/>
+					</Zoom>
+				</div>
 			</section>
 
 			{/* Overview section */}


### PR DESCRIPTION
## Summary

Removes React Suspense boundaries and async component patterns now that all data is statically imported.

## Changes Made

- Removed Suspense import and wrapper components from main page
- Removed skeleton loading components
- Converted Experience and Projects components from async to synchronous
- Removed Suspense wrapper from SingleProject component  
- Updated image loading strategy from lazy to eager

## Why These Changes?

After migrating to static data imports, Suspense boundaries and loading skeletons are no longer necessary since data is immediately available at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)