### PR TITLE
feat(seo): site-wide seo foundation

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -35,10 +35,16 @@ jobs:
         run: npm install -g @lhci/cli@0.13.x
 
       - name: Run Lighthouse CI
-        run: |
-          lhci autorun --collect.url=${{ steps.vercel.outputs.url }} --collect.numberOfRuns=3
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          DEPLOY_URL: ${{ steps.vercel.outputs.url }}
+        run: |
+          CONFIG="lighthouserc.json"
+          if [[ "$REF_NAME" == "main" ]]; then
+            CONFIG="lighthouserc.production.json"
+          fi
+          lhci autorun --config="$CONFIG" --collect.url="$DEPLOY_URL" --collect.numberOfRuns=3
 
       - name: Upload Lighthouse results
         uses: actions/upload-artifact@v4

--- a/docs/superpowers/plans/2026-04-21-seo-improvements.md
+++ b/docs/superpowers/plans/2026-04-21-seo-improvements.md
@@ -1,0 +1,1135 @@
+# SEO Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a complete SEO foundation to the portfolio: per-route metadata,
+dynamic OG images, sitemap, robots, and JSON-LD structured data.
+
+**Architecture:** A shared `src/lib/seo.ts` module owns URL resolution, host
+checks, and small helpers (singleton pattern per the project's `performance.md`
+rule). Next.js App Router file conventions provide `sitemap.ts`, `robots.ts`,
+and `opengraph-image.tsx` routes. A shared `src/lib/og-template.tsx` renders all
+OG images with one visual identity. Per-route `generateMetadata` functions
+consume `siteConfig` and the project/experience data modules.
+
+**Tech Stack:** Next.js 15 App Router, TypeScript strict, Vitest, Tailwind v4,
+`ImageResponse` (Satori).
+
+**Spec:** `docs/superpowers/specs/2026-04-21-seo-improvements-design.md`
+
+**Important data-model note (correcting spec field names):**
+
+- `Project` exposes `title` (not `name`), plus `description`, `stack`, `image`,
+  `url`, `slug`.
+- `Experience` exposes `position` (not `role`), plus `company`, `startDate`,
+  `endDate`, `description`, `slug`.
+- Tasks below use these correct field names.
+
+**JSON-LD injection safety (applies to Tasks 4 and 7):** All JSON-LD blocks are
+injected via `dangerouslySetInnerHTML` with `JSON.stringify` output. Input is
+sourced exclusively from compile-time modules (`siteConfig`, `projects`) — no
+user input, no external data. `JSON.stringify` escapes the characters needed for
+safe `<script>` embedding. This is the standard Next.js pattern for structured
+data; no sanitizer needed.
+
+**OG-font decision (YAGNI deviation from spec):** The OG template uses Satori's
+default sans-serif font. Custom Montserrat loading inside `ImageResponse` adds
+fragility (external font fetch, binary parsing) for marginal visual gain.
+Dark-purple background + accent bar + left-aligned layout still matches site
+identity. Custom font is a follow-up if desired.
+
+---
+
+## Task 1: SEO primitives module with tests
+
+**Files:**
+
+- Create: `src/lib/seo.ts`
+- Create: `src/lib/seo.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/lib/seo.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+describe("seo primitives", () => {
+	const ORIGINAL_ENV = { ...process.env };
+
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		process.env = { ...ORIGINAL_ENV };
+	});
+
+	describe("siteUrl", () => {
+		it("uses NEXT_PUBLIC_SITE_URL when set", async () => {
+			process.env.NEXT_PUBLIC_SITE_URL = "https://example.com";
+			const { siteUrl } = await import("./seo");
+			expect(siteUrl.toString()).toBe("https://example.com/");
+		});
+
+		it("falls back to https://VERCEL_URL when only VERCEL_URL is set", async () => {
+			delete process.env.NEXT_PUBLIC_SITE_URL;
+			process.env.VERCEL_URL = "my-preview.vercel.app";
+			const { siteUrl } = await import("./seo");
+			expect(siteUrl.toString()).toBe("https://my-preview.vercel.app/");
+		});
+
+		it("falls back to https://www.julisv.com when neither env var is set", async () => {
+			delete process.env.NEXT_PUBLIC_SITE_URL;
+			delete process.env.VERCEL_URL;
+			const { siteUrl } = await import("./seo");
+			expect(siteUrl.toString()).toBe("https://www.julisv.com/");
+		});
+	});
+
+	describe("absoluteUrl", () => {
+		it("builds an absolute URL from a pathname with leading slash", async () => {
+			process.env.NEXT_PUBLIC_SITE_URL = "https://www.julisv.com";
+			const { absoluteUrl } = await import("./seo");
+			expect(absoluteUrl("/project/tailorsift")).toBe(
+				"https://www.julisv.com/project/tailorsift"
+			);
+		});
+
+		it("handles the root path", async () => {
+			process.env.NEXT_PUBLIC_SITE_URL = "https://www.julisv.com";
+			const { absoluteUrl } = await import("./seo");
+			expect(absoluteUrl("/")).toBe("https://www.julisv.com/");
+		});
+	});
+
+	describe("isProductionHost", () => {
+		it("returns true for www.julisv.com", async () => {
+			const { isProductionHost } = await import("./seo");
+			expect(isProductionHost(new URL("https://www.julisv.com"))).toBe(true);
+		});
+
+		it("returns false for preview host", async () => {
+			const { isProductionHost } = await import("./seo");
+			expect(isProductionHost(new URL("https://preview.vercel.app"))).toBe(
+				false
+			);
+		});
+
+		it("returns false for localhost", async () => {
+			const { isProductionHost } = await import("./seo");
+			expect(isProductionHost(new URL("http://localhost:3000"))).toBe(false);
+		});
+
+		it("returns false for apex julisv.com (no www)", async () => {
+			const { isProductionHost } = await import("./seo");
+			expect(isProductionHost(new URL("https://julisv.com"))).toBe(false);
+		});
+	});
+
+	describe("truncate", () => {
+		it("returns the input unchanged when shorter than max", async () => {
+			const { truncate } = await import("./seo");
+			expect(truncate("short", 160)).toBe("short");
+		});
+
+		it("truncates at word boundary and appends ellipsis", async () => {
+			const { truncate } = await import("./seo");
+			const input =
+				"This is a long description that will definitely exceed the limit when we set the limit low enough to see truncation";
+			const out = truncate(input, 40);
+			expect(out.length).toBeLessThanOrEqual(40);
+			expect(out.endsWith("…")).toBe(true);
+			expect(out).not.toContain("  ");
+		});
+
+		it("handles empty string", async () => {
+			const { truncate } = await import("./seo");
+			expect(truncate("", 160)).toBe("");
+		});
+	});
+
+	describe("DEFAULT_OG_SIZE", () => {
+		it("is 1200x630", async () => {
+			const { DEFAULT_OG_SIZE } = await import("./seo");
+			expect(DEFAULT_OG_SIZE).toEqual({ width: 1200, height: 630 });
+		});
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/lib/seo.test.ts` Expected: FAIL — "Cannot find module
+'./seo'" or similar.
+
+- [ ] **Step 3: Implement `src/lib/seo.ts`**
+
+Create `src/lib/seo.ts`:
+
+```ts
+const DEFAULT_SITE_URL = "https://www.julisv.com";
+
+function resolveSiteUrl(): URL {
+	const explicit = process.env.NEXT_PUBLIC_SITE_URL;
+	if (explicit) return new URL(explicit);
+
+	const vercel = process.env.VERCEL_URL;
+	if (vercel) return new URL(`https://${vercel}`);
+
+	return new URL(DEFAULT_SITE_URL);
+}
+
+export const siteUrl: URL = resolveSiteUrl();
+
+export const DEFAULT_OG_SIZE = { width: 1200, height: 630 } as const;
+
+export function isProductionHost(url: URL): boolean {
+	return url.host === "www.julisv.com";
+}
+
+export function absoluteUrl(path: string): string {
+	return new URL(path, siteUrl).toString();
+}
+
+export function truncate(str: string, max = 160): string {
+	if (str.length <= max) return str;
+	const sliced = str.slice(0, max - 1);
+	const lastSpace = sliced.lastIndexOf(" ");
+	const cut = lastSpace > max * 0.6 ? sliced.slice(0, lastSpace) : sliced;
+	return `${cut.trimEnd()}…`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test src/lib/seo.test.ts` Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/seo.ts src/lib/seo.test.ts
+git commit -m "feat(seo): add seo primitives module with url resolution helpers"
+```
+
+---
+
+## Task 2: Robots route with tests
+
+**Files:**
+
+- Create: `src/app/robots.ts`
+- Create: `src/app/robots.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/app/robots.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+describe("robots()", () => {
+	const ORIGINAL_ENV = { ...process.env };
+
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		process.env = { ...ORIGINAL_ENV };
+	});
+
+	it("allows all crawling on production host and includes sitemap", async () => {
+		process.env.NEXT_PUBLIC_SITE_URL = "https://www.julisv.com";
+		const robots = (await import("./robots")).default;
+		const result = robots();
+		expect(result.rules).toEqual([{ userAgent: "*", allow: "/" }]);
+		expect(result.sitemap).toBe("https://www.julisv.com/sitemap.xml");
+		expect(result.host).toBe("www.julisv.com");
+	});
+
+	it("disallows all crawling on preview host and omits sitemap", async () => {
+		process.env.NEXT_PUBLIC_SITE_URL = "https://preview.vercel.app";
+		const robots = (await import("./robots")).default;
+		const result = robots();
+		expect(result.rules).toEqual([{ userAgent: "*", disallow: "/" }]);
+		expect(result.sitemap).toBeUndefined();
+	});
+
+	it("disallows all crawling when siteUrl falls back to VERCEL_URL", async () => {
+		delete process.env.NEXT_PUBLIC_SITE_URL;
+		process.env.VERCEL_URL = "my-preview.vercel.app";
+		const robots = (await import("./robots")).default;
+		const result = robots();
+		expect(result.rules).toEqual([{ userAgent: "*", disallow: "/" }]);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/app/robots.test.ts` Expected: FAIL — "Cannot find module
+'./robots'".
+
+- [ ] **Step 3: Implement `src/app/robots.ts`**
+
+Create `src/app/robots.ts`:
+
+```ts
+import type { MetadataRoute } from "next";
+import { siteUrl, isProductionHost, absoluteUrl } from "@/lib/seo";
+
+export default function robots(): MetadataRoute.Robots {
+	if (isProductionHost(siteUrl)) {
+		return {
+			rules: [{ userAgent: "*", allow: "/" }],
+			sitemap: absoluteUrl("/sitemap.xml"),
+			host: "www.julisv.com",
+		};
+	}
+	return {
+		rules: [{ userAgent: "*", disallow: "/" }],
+	};
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test src/app/robots.test.ts` Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/robots.ts src/app/robots.test.ts
+git commit -m "feat(seo): add robots.ts to block preview deploys and allow production"
+```
+
+---
+
+## Task 3: Sitemap route with tests
+
+**Files:**
+
+- Create: `src/app/sitemap.ts`
+- Create: `src/app/sitemap.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/app/sitemap.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { sortedProjects } from "@/data/projects";
+import { sortedExperiences } from "@/data/experience";
+
+describe("sitemap()", () => {
+	const ORIGINAL_ENV = { ...process.env };
+
+	beforeEach(() => {
+		vi.resetModules();
+		process.env.NEXT_PUBLIC_SITE_URL = "https://www.julisv.com";
+	});
+
+	afterEach(() => {
+		process.env = { ...ORIGINAL_ENV };
+	});
+
+	it("includes home, archive, all projects, and all experiences", async () => {
+		const sitemap = (await import("./sitemap")).default;
+		const entries = sitemap();
+
+		const urls = entries.map((e) => e.url);
+		expect(urls).toContain("https://www.julisv.com/");
+		expect(urls).toContain("https://www.julisv.com/archive");
+		for (const p of sortedProjects) {
+			expect(urls).toContain(`https://www.julisv.com/project/${p.slug}`);
+		}
+		for (const e of sortedExperiences) {
+			expect(urls).toContain(`https://www.julisv.com/experience/${e.slug}`);
+		}
+	});
+
+	it("has the expected total count", async () => {
+		const sitemap = (await import("./sitemap")).default;
+		const entries = sitemap();
+		expect(entries.length).toBe(
+			sortedProjects.length + sortedExperiences.length + 2
+		);
+	});
+
+	it("all urls start with the configured site url", async () => {
+		const sitemap = (await import("./sitemap")).default;
+		const entries = sitemap();
+		for (const e of entries) {
+			expect(e.url.startsWith("https://www.julisv.com/")).toBe(true);
+		}
+	});
+
+	it("every entry has a lastModified date", async () => {
+		const sitemap = (await import("./sitemap")).default;
+		const entries = sitemap();
+		for (const e of entries) {
+			expect(e.lastModified).toBeInstanceOf(Date);
+		}
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/app/sitemap.test.ts` Expected: FAIL — "Cannot find module
+'./sitemap'".
+
+- [ ] **Step 3: Implement `src/app/sitemap.ts`**
+
+Create `src/app/sitemap.ts`:
+
+```ts
+import type { MetadataRoute } from "next";
+import { absoluteUrl } from "@/lib/seo";
+import { sortedProjects } from "@/data/projects";
+import { sortedExperiences } from "@/data/experience";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+	const now = new Date();
+
+	const staticEntries: MetadataRoute.Sitemap = [
+		{
+			url: absoluteUrl("/"),
+			lastModified: now,
+			changeFrequency: "monthly",
+			priority: 1,
+		},
+		{
+			url: absoluteUrl("/archive"),
+			lastModified: now,
+			changeFrequency: "monthly",
+			priority: 0.7,
+		},
+	];
+
+	const projectEntries: MetadataRoute.Sitemap = sortedProjects.map((p) => ({
+		url: absoluteUrl(`/project/${p.slug}`),
+		lastModified: now,
+		changeFrequency: "yearly",
+		priority: 0.8,
+	}));
+
+	const experienceEntries: MetadataRoute.Sitemap = sortedExperiences.map(
+		(e) => ({
+			url: absoluteUrl(`/experience/${e.slug}`),
+			lastModified: now,
+			changeFrequency: "yearly",
+			priority: 0.6,
+		})
+	);
+
+	return [...staticEntries, ...projectEntries, ...experienceEntries];
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test src/app/sitemap.test.ts` Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/sitemap.ts src/app/sitemap.test.ts
+git commit -m "feat(seo): add sitemap covering home, archive, projects, experiences"
+```
+
+---
+
+## Task 4: Root layout metadata + Person JSON-LD
+
+**Files:**
+
+- Modify: `src/app/layout.tsx`
+
+No new unit test — metadata is data-plumbing covered by the build and manual
+source inspection in Task 12.
+
+- [ ] **Step 1: Rewrite `src/app/layout.tsx`**
+
+Replace the entire file with:
+
+```tsx
+import type { Metadata } from "next";
+import { Montserrat } from "next/font/google";
+import "./globals.css";
+import { PostHogProvider } from "../providers/ph-provider";
+import { siteUrl, absoluteUrl } from "@/lib/seo";
+import { siteConfig } from "@/data/site";
+
+const DESCRIPTION =
+	"Full-stack web developer specializing in Next.js, React, and TypeScript. Building fast, accessible, and well-crafted web experiences.";
+
+export const metadata: Metadata = {
+	metadataBase: siteUrl,
+	title: {
+		default: `${siteConfig.name} — Full-stack web developer`,
+		template: `%s · ${siteConfig.name}`,
+	},
+	description: DESCRIPTION,
+	authors: [{ name: siteConfig.name, url: siteUrl.toString() }],
+	alternates: { canonical: "/" },
+	openGraph: {
+		type: "website",
+		url: "/",
+		siteName: siteConfig.name,
+		locale: "en_US",
+		title: `${siteConfig.name} — Full-stack web developer`,
+		description: DESCRIPTION,
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: `${siteConfig.name} — Full-stack web developer`,
+		description: DESCRIPTION,
+	},
+	robots: { index: true, follow: true },
+};
+
+const montserrat = Montserrat({
+	subsets: ["latin"],
+});
+
+const personJsonLd = {
+	"@context": "https://schema.org",
+	"@type": "Person",
+	name: siteConfig.name,
+	url: absoluteUrl("/"),
+	jobTitle: "Full-stack web developer",
+	sameAs: [siteConfig.socialLinks.github, siteConfig.socialLinks.linkedin],
+};
+
+export default function RootLayout({
+	children,
+}: Readonly<{
+	children: React.ReactNode;
+}>) {
+	return (
+		<html lang="en" className={`scroll-smooth ` + montserrat.className}>
+			<body className="bg-dark-purple leading-relaxed text-slate-400 antialiased selection:bg-sky-400 selection:text-slate-900">
+				<script
+					type="application/ld+json"
+					// JSON-LD content is compile-time (siteConfig); JSON.stringify handles escaping.
+					dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+				/>
+				<PostHogProvider>{children}</PostHogProvider>
+			</body>
+		</html>
+	);
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck` Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/layout.tsx
+git commit -m "feat(seo): expand root metadata with og, twitter, canonical, and person json-ld"
+```
+
+---
+
+## Task 5: Shared OG image template
+
+**Files:**
+
+- Create: `src/lib/og-template.tsx`
+
+No unit test — visual output verified by manual inspection and build success.
+
+- [ ] **Step 1: Create `src/lib/og-template.tsx`**
+
+```tsx
+import type { ReactElement } from "react";
+
+interface OgTemplateProps {
+	eyebrow: string;
+	title: string;
+	subtitle: string;
+	footer?: string | ReactElement;
+}
+
+const DARK_PURPLE = "#0a0a23";
+const SKY_400 = "#38bdf8";
+const SLATE_100 = "#f1f5f9";
+const SLATE_400 = "#94a3b8";
+
+export function renderOgImage({
+	eyebrow,
+	title,
+	subtitle,
+	footer,
+}: OgTemplateProps): ReactElement {
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				justifyContent: "space-between",
+				backgroundColor: DARK_PURPLE,
+				padding: "80px",
+				color: SLATE_100,
+				fontFamily: "sans-serif",
+			}}
+		>
+			<div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
+				<div style={{ display: "flex", alignItems: "center", gap: "16px" }}>
+					<div
+						style={{ width: "48px", height: "4px", backgroundColor: SKY_400 }}
+					/>
+					<span
+						style={{
+							fontSize: "24px",
+							textTransform: "uppercase",
+							letterSpacing: "4px",
+							color: SKY_400,
+						}}
+					>
+						{eyebrow}
+					</span>
+				</div>
+				<h1
+					style={{
+						fontSize: "84px",
+						lineHeight: 1.05,
+						fontWeight: 700,
+						margin: 0,
+						maxWidth: "1000px",
+					}}
+				>
+					{title}
+				</h1>
+				<p
+					style={{
+						fontSize: "36px",
+						lineHeight: 1.3,
+						color: SLATE_400,
+						margin: 0,
+						maxWidth: "1000px",
+					}}
+				>
+					{subtitle}
+				</p>
+			</div>
+			<div
+				style={{
+					display: "flex",
+					justifyContent: "space-between",
+					alignItems: "flex-end",
+					fontSize: "24px",
+					color: SLATE_400,
+				}}
+			>
+				<span style={{ display: "flex" }}>julisv.com</span>
+				{footer ? <span style={{ display: "flex" }}>{footer}</span> : null}
+			</div>
+		</div>
+	);
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck` Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/og-template.tsx
+git commit -m "feat(seo): add shared og image template"
+```
+
+---
+
+## Task 6: Home OG image
+
+**Files:**
+
+- Create: `src/app/opengraph-image.tsx`
+
+- [ ] **Step 1: Create `src/app/opengraph-image.tsx`**
+
+```tsx
+import { ImageResponse } from "next/og";
+import { renderOgImage } from "@/lib/og-template";
+import { DEFAULT_OG_SIZE } from "@/lib/seo";
+import { siteConfig } from "@/data/site";
+
+export const runtime = "nodejs";
+export const alt = `${siteConfig.name} — Full-stack web developer`;
+export const size = DEFAULT_OG_SIZE;
+export const contentType = "image/png";
+
+export default async function Image() {
+	return new ImageResponse(
+		renderOgImage({
+			eyebrow: "Portfolio",
+			title: siteConfig.name,
+			subtitle: "Full-stack web developer — Next.js, React, TypeScript",
+		}),
+		{ ...DEFAULT_OG_SIZE }
+	);
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck` Expected: no errors.
+
+- [ ] **Step 3: Build smoke check**
+
+Run: `pnpm build` Expected: build succeeds, output shows `/opengraph-image`
+route generated.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/opengraph-image.tsx
+git commit -m "feat(seo): add home opengraph image"
+```
+
+---
+
+## Task 7: Project route metadata + CreativeWork JSON-LD
+
+**Files:**
+
+- Modify: `src/app/(front)/project/[slug]/page.tsx`
+
+- [ ] **Step 1: Rewrite `src/app/(front)/project/[slug]/page.tsx`**
+
+Replace the file with:
+
+```tsx
+import type { Metadata } from "next";
+import SingleProject from "@/features/front/projects/components/SingleProject";
+import { sortedProjects, getProjectBySlug } from "@/data";
+import { absoluteUrl, truncate } from "@/lib/seo";
+
+interface PageProps {
+	params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+	params,
+}: PageProps): Promise<Metadata> {
+	const { slug } = await params;
+	const project = getProjectBySlug(slug);
+	if (!project) return {};
+
+	const description = truncate(project.description);
+	const canonical = `/project/${project.slug}`;
+
+	return {
+		title: project.title,
+		description,
+		keywords: project.stack,
+		alternates: { canonical },
+		openGraph: {
+			type: "article",
+			url: canonical,
+			title: project.title,
+			description,
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: project.title,
+			description,
+		},
+	};
+}
+
+const ProjectPage = async (props: PageProps) => {
+	const params = await props.params;
+	const project = getProjectBySlug(params.slug);
+
+	const jsonLd = project
+		? {
+				"@context": "https://schema.org",
+				"@type": "CreativeWork",
+				name: project.title,
+				description: project.description,
+				url: project.url,
+				author: { "@type": "Person", name: "Julian Suarez Vivas" },
+				keywords: project.stack.join(", "),
+				image: absoluteUrl(project.image),
+			}
+		: null;
+
+	return (
+		<>
+			{jsonLd ? (
+				<script
+					type="application/ld+json"
+					// JSON-LD content is compile-time (projects data); JSON.stringify handles escaping.
+					dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+				/>
+			) : null}
+			<SingleProject slug={params.slug} />
+		</>
+	);
+};
+
+export default ProjectPage;
+
+export const dynamic = "force-static";
+
+export async function generateStaticParams() {
+	return sortedProjects.map((project) => ({
+		slug: project.slug,
+	}));
+}
+```
+
+- [ ] **Step 2: Typecheck + existing tests**
+
+Run: `pnpm typecheck && pnpm test` Expected: no errors, all existing tests still
+pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "src/app/(front)/project/[slug]/page.tsx"
+git commit -m "feat(seo): add project route metadata and creativework json-ld"
+```
+
+---
+
+## Task 8: Project OG image
+
+**Files:**
+
+- Create: `src/app/(front)/project/[slug]/opengraph-image.tsx`
+
+- [ ] **Step 1: Create the file**
+
+```tsx
+import { ImageResponse } from "next/og";
+import { renderOgImage } from "@/lib/og-template";
+import { DEFAULT_OG_SIZE, truncate } from "@/lib/seo";
+import { getProjectBySlug, sortedProjects } from "@/data";
+
+export const runtime = "nodejs";
+export const alt = "Project preview";
+export const size = DEFAULT_OG_SIZE;
+export const contentType = "image/png";
+
+export async function generateStaticParams() {
+	return sortedProjects.map((p) => ({ slug: p.slug }));
+}
+
+interface ImageProps {
+	params: Promise<{ slug: string }>;
+}
+
+export default async function Image({ params }: ImageProps) {
+	const { slug } = await params;
+	const project = getProjectBySlug(slug);
+	const title = project?.title ?? "Project";
+	const subtitle = project
+		? truncate(project.description, 120)
+		: "Portfolio project";
+	const stackChips = project ? project.stack.slice(0, 4).join(" · ") : "";
+
+	return new ImageResponse(
+		renderOgImage({
+			eyebrow: "Project",
+			title,
+			subtitle,
+			footer: stackChips,
+		}),
+		{ ...DEFAULT_OG_SIZE }
+	);
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck` Expected: no errors.
+
+- [ ] **Step 3: Build smoke check**
+
+Run: `pnpm build` Expected: build succeeds; output shows one OG image route
+generated per project slug.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "src/app/(front)/project/[slug]/opengraph-image.tsx"
+git commit -m "feat(seo): add per-project opengraph image"
+```
+
+---
+
+## Task 9: Experience route metadata
+
+**Files:**
+
+- Modify: `src/app/experience/[slug]/page.tsx`
+
+- [ ] **Step 1: Rewrite the file**
+
+```tsx
+import type { Metadata } from "next";
+import ExperienceDetail from "@/features/front/experience/components/ExperienceDetail";
+import { sortedExperiences, getExperienceBySlug } from "@/data";
+import { truncate } from "@/lib/seo";
+
+interface PageProps {
+	params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+	params,
+}: PageProps): Promise<Metadata> {
+	const { slug } = await params;
+	const experience = getExperienceBySlug(slug);
+	if (!experience) return {};
+
+	const title = `${experience.position} at ${experience.company}`;
+	const description = truncate(experience.description);
+	const canonical = `/experience/${experience.slug}`;
+
+	return {
+		title,
+		description,
+		alternates: { canonical },
+		openGraph: {
+			type: "article",
+			url: canonical,
+			title,
+			description,
+		},
+		twitter: {
+			card: "summary_large_image",
+			title,
+			description,
+		},
+	};
+}
+
+const ExperiencePage = async (props: PageProps) => {
+	const params = await props.params;
+	return <ExperienceDetail slug={params.slug} />;
+};
+
+export default ExperiencePage;
+
+export const dynamic = "force-static";
+
+export async function generateStaticParams() {
+	return sortedExperiences.map((exp) => ({
+		slug: exp.slug,
+	}));
+}
+```
+
+- [ ] **Step 2: Typecheck + existing tests**
+
+Run: `pnpm typecheck && pnpm test` Expected: no errors, all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "src/app/experience/[slug]/page.tsx"
+git commit -m "feat(seo): add experience route metadata"
+```
+
+---
+
+## Task 10: Experience OG image
+
+**Files:**
+
+- Create: `src/app/experience/[slug]/opengraph-image.tsx`
+
+- [ ] **Step 1: Create the file**
+
+```tsx
+import { ImageResponse } from "next/og";
+import { renderOgImage } from "@/lib/og-template";
+import { DEFAULT_OG_SIZE } from "@/lib/seo";
+import { getExperienceBySlug, sortedExperiences } from "@/data";
+
+export const runtime = "nodejs";
+export const alt = "Experience preview";
+export const size = DEFAULT_OG_SIZE;
+export const contentType = "image/png";
+
+export async function generateStaticParams() {
+	return sortedExperiences.map((e) => ({ slug: e.slug }));
+}
+
+interface ImageProps {
+	params: Promise<{ slug: string }>;
+}
+
+export default async function Image({ params }: ImageProps) {
+	const { slug } = await params;
+	const experience = getExperienceBySlug(slug);
+	const title = experience?.position ?? "Experience";
+	const subtitle = experience?.company ?? "";
+	const dateRange = experience
+		? `${experience.startDate} — ${experience.endDate}`
+		: "";
+
+	return new ImageResponse(
+		renderOgImage({
+			eyebrow: "Experience",
+			title,
+			subtitle,
+			footer: dateRange,
+		}),
+		{ ...DEFAULT_OG_SIZE }
+	);
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck` Expected: no errors.
+
+- [ ] **Step 3: Build smoke check**
+
+Run: `pnpm build` Expected: build succeeds; OG image route generated per
+experience slug.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "src/app/experience/[slug]/opengraph-image.tsx"
+git commit -m "feat(seo): add per-experience opengraph image"
+```
+
+---
+
+## Task 11: Archive page metadata
+
+**Files:**
+
+- Modify: `src/app/(front)/archive/page.tsx`
+
+- [ ] **Step 1: Read the current file**
+
+Run: `cat "src/app/(front)/archive/page.tsx"`
+
+- [ ] **Step 2: Add a `metadata` export to the top of the file**
+
+Add this import (if not already present) and this `metadata` export. Do not
+remove or alter any existing code in the file.
+
+```tsx
+import type { Metadata } from "next";
+
+const ARCHIVE_DESCRIPTION =
+	"The complete archive of projects I've built — websites, web apps, and experiments.";
+
+export const metadata: Metadata = {
+	title: "Archive",
+	description: ARCHIVE_DESCRIPTION,
+	alternates: { canonical: "/archive" },
+	openGraph: {
+		type: "website",
+		url: "/archive",
+		title: "Archive",
+		description: ARCHIVE_DESCRIPTION,
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: "Archive",
+		description: ARCHIVE_DESCRIPTION,
+	},
+};
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm typecheck` Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "src/app/(front)/archive/page.tsx"
+git commit -m "feat(seo): add metadata to archive page"
+```
+
+---
+
+## Task 12: Full-suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full validation suite**
+
+Run: `pnpm validate` Expected: lint + typecheck + format + tests + build all
+pass.
+
+- [ ] **Step 2: Run production server and check SEO routes**
+
+Run (background): `pnpm start` Expected: server starts on
+`http://localhost:3000`.
+
+Then with `curl` or a browser, confirm:
+
+- `curl -s http://localhost:3000/robots.txt` — shows `User-Agent: *` plus either
+  `Allow: /` (if `NEXT_PUBLIC_SITE_URL=https://www.julisv.com`) or `Disallow: /`
+  (otherwise).
+- `curl -s http://localhost:3000/sitemap.xml | head -20` — XML with `<url>`
+  entries for home, archive, projects, experiences.
+- `http://localhost:3000/project/tailorsift` → View Source → confirm:
+  - `<title>TailorSift · Julian Suarez Vivas</title>` (title template applied).
+  - `<meta property="og:image" ...>` pointing to
+    `/project/tailorsift/opengraph-image`.
+  - `<meta name="twitter:card" content="summary_large_image">`.
+  - `<link rel="canonical" href=".../project/tailorsift">`.
+  - `<script type="application/ld+json">` containing `"@type":"CreativeWork"`.
+- `http://localhost:3000/opengraph-image` → PNG renders with "Portfolio"
+  eyebrow, name, subtitle.
+
+Stop the server when done (Ctrl+C or `kill %1`).
+
+- [ ] **Step 3: Configure Vercel env var (manual, no code change)**
+
+In Vercel project settings:
+
+- Production environment: add `NEXT_PUBLIC_SITE_URL=https://www.julisv.com`.
+- Preview / development environments: leave unset (so `isProductionHost` is
+  false and robots disallow indexing).
+
+This step is an out-of-repo action — no commit.
+
+- [ ] **Step 4: Post-deploy verification (after merge + deploy)**
+
+Once live on `https://www.julisv.com`:
+
+- LinkedIn Post Inspector (`https://www.linkedin.com/post-inspector/`) — paste
+  home URL and a project URL; confirm image, title, description render.
+- Twitter Card Validator (`https://cards-dev.twitter.com/validator`) — same
+  URLs; confirm large-image card.
+- Google Rich Results Test (`https://search.google.com/test/rich-results`) —
+  home URL should detect `Person`, project URL should detect `CreativeWork`.
+- Confirm `https://www.julisv.com/robots.txt` shows `Allow: /` and lists the
+  sitemap.
+- Confirm a Vercel preview URL's `/robots.txt` shows `Disallow: /`.
+
+Manual checklist — no commit required.
+
+---
+
+## Done
+
+All 12 tasks complete → portfolio has full SEO foundation: per-route metadata,
+dynamic OG images, sitemap, robots with preview-deploy blocking, and structured
+data.

--- a/docs/superpowers/specs/2026-04-21-seo-improvements-design.md
+++ b/docs/superpowers/specs/2026-04-21-seo-improvements-design.md
@@ -1,0 +1,312 @@
+# SEO Improvements — Design Spec
+
+- **Date:** 2026-04-21
+- **Owner:** Julian Suarez Vivas
+- **Status:** Approved (pending user review of this doc)
+- **Scope:** Site-wide SEO foundation for the portfolio
+
+## Goal
+
+Give the portfolio a complete SEO foundation so that:
+
+- Google and other search engines can discover and index every route.
+- Links shared on LinkedIn / Twitter / Slack render rich previews with per-route
+  OG images, titles, and descriptions.
+- Structured data (`Person`, `CreativeWork`) helps search engines understand the
+  portfolio's content.
+- Preview/staging deploys are not indexed.
+
+## Current State
+
+- `src/app/layout.tsx` has only `title` + `description`. No `metadataBase`, no
+  title template, no OG, no Twitter cards, no canonical.
+- `/project/[slug]` and `/experience/[slug]` export no metadata at all.
+- `/archive` exports no metadata.
+- No `sitemap.ts` or `robots.ts`.
+- No OG images (static or dynamic).
+- No JSON-LD structured data.
+- `lighthouserc.json` sets `is-crawlable: off`, masking the absence of
+  robots/crawl-control logic.
+- Production URL: `https://www.julisv.com`.
+
+## Decisions Locked In
+
+- Production canonical: `https://www.julisv.com`.
+- Site URL resolution: env-var with fallback (flexible across environments).
+- OG images: dynamic per-route via `opengraph-image.tsx` (`ImageResponse`).
+- Twitter card: `summary_large_image`, no `creator` handle.
+
+## Architecture
+
+### `src/lib/seo.ts` — SEO primitives (singleton)
+
+Single source of truth. Parsed/constructed once at module init per the
+`performance.md` rule.
+
+Exports:
+
+- `siteUrl: URL` —
+  `new URL(process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.julisv.com")`. If
+  `NEXT_PUBLIC_SITE_URL` is unset but `VERCEL_URL` is set (preview deploys), use
+  `https://${VERCEL_URL}` so preview OG URLs are absolute and functional.
+- `isProductionHost(url: URL): boolean` — true iff
+  `url.host === "www.julisv.com"`. Used by `robots.ts` to switch between
+  allow/disallow.
+- `absoluteUrl(path: string): string` — `new URL(path, siteUrl).toString()`.
+- `truncate(str: string, max = 160): string` — clean truncation at word
+  boundaries with a trailing ellipsis; used for OG/meta descriptions.
+- `DEFAULT_OG_SIZE` — `{ width: 1200, height: 630 }` constant.
+
+No runtime Zod parsing inside any exported function.
+
+### `src/lib/og-template.tsx` — shared OG image template
+
+Exports `renderOgImage({ eyebrow, title, subtitle, footer })` returning a
+`ReactElement` consumed by `ImageResponse`. Inline styles only (no Tailwind).
+Visual identity matches site:
+
+- 1200×630, dark-purple background.
+- Left-aligned layout.
+- Thin sky-400 accent bar.
+- Montserrat weights loaded from Google Fonts via `fetch(...).arrayBuffer()`
+  once per module (Next caches at build time).
+- Footer always shows `julisv.com`.
+
+## Root Metadata — `src/app/layout.tsx`
+
+Replace the current 3-field `metadata` export with:
+
+- `metadataBase: siteUrl`
+- `title: { default: "Julian Suarez Vivas — Full-stack web developer", template: "%s · Julian Suarez Vivas" }`
+- `description`: existing copy retained.
+- `authors: [{ name: siteConfig.name, url: siteUrl.toString() }]`
+- `alternates: { canonical: "/" }`
+- `openGraph`: `type: "website"`, `url: "/"`, `siteName: siteConfig.name`,
+  `locale: "en_US"`, title, description.
+- `twitter`: `card: "summary_large_image"`, title, description.
+- `robots`: `{ index: true, follow: true }`. Preview-deploy blocking lives in
+  `robots.ts` globally; no per-page overrides.
+
+OG image for the home route is auto-discovered from
+`src/app/opengraph-image.tsx`.
+
+### JSON-LD `Person` schema
+
+Server-rendered `<script type="application/ld+json">` in `layout.tsx` `<body>`.
+Pulls from `siteConfig` — no duplication:
+
+```json
+{
+	"@context": "https://schema.org",
+	"@type": "Person",
+	"name": "Julian Suarez Vivas",
+	"url": "https://www.julisv.com",
+	"jobTitle": "Full-stack web developer",
+	"sameAs": ["<github>", "<linkedin>"]
+}
+```
+
+**Safety note:** injection uses `dangerouslySetInnerHTML` with
+`JSON.stringify()` output. Input is sourced entirely from `src/data/site.ts`
+(`siteConfig`) — compile-time constants, no user input, no external fetch.
+`JSON.stringify` safely escapes `<`, `>`, and quotes for embedding inside a
+`<script>` tag. This is the standard Next.js pattern for JSON-LD; no sanitizer
+needed. If the schema ever incorporates user-controlled data in the future,
+switch to a sanitizer or escape `</` explicitly.
+
+## Per-Route Metadata
+
+### `src/app/(front)/project/[slug]/page.tsx`
+
+Add `generateMetadata({ params })`:
+
+- `title: project.name` (becomes `"TailorSift · Julian Suarez Vivas"`).
+- `description: truncate(project.description)`.
+- `keywords: project.stack`.
+- `alternates: { canonical: ` /project/${slug} ` }`.
+- `openGraph: { type: "article", url: ` /project/${slug}
+  `, title, description }`.
+- `twitter: { card: "summary_large_image", title, description }`.
+
+If `getProjectBySlug(slug)` returns `undefined`, return `{}`; existing not-found
+behavior handles the rest.
+
+Also inject a `CreativeWork` JSON-LD on the page (same safety note as the
+`Person` schema — input sourced from `projects` data module, stringified):
+
+```json
+{
+	"@context": "https://schema.org",
+	"@type": "CreativeWork",
+	"name": "<project.name>",
+	"description": "<project.description>",
+	"url": "<project.url>",
+	"author": { "@type": "Person", "name": "Julian Suarez Vivas" },
+	"keywords": "<project.stack joined by comma>",
+	"image": "<absoluteUrl(project.image)>"
+}
+```
+
+### `src/app/experience/[slug]/page.tsx`
+
+Add `generateMetadata({ params })`:
+
+- `title: ${role} at ${company}`.
+- `description: truncate(experience.summary)`.
+- `alternates: { canonical: ` /experience/${slug} ` }`.
+- `openGraph: { type: "article", url, title, description }`.
+- `twitter: { card: "summary_large_image", title, description }`.
+
+No JSON-LD — `Person` on home covers employment history; adding `WorkExperience`
+here would be noise.
+
+### `src/app/(front)/archive/page.tsx`
+
+Static `metadata` export:
+
+- `title: "Archive"`.
+- `description`: describes the full project list.
+- `alternates: { canonical: "/archive" }`.
+- OG + Twitter mirroring title/description.
+
+## Dynamic OG Images
+
+Three `opengraph-image.tsx` routes. All use `ImageResponse` and the shared
+`renderOgImage` template. Runtime: **Node** (keeps data imports simple; Next
+caches output at build time).
+
+Each file exports:
+
+- `alt: string`
+- `size = DEFAULT_OG_SIZE`
+- `contentType = "image/png"`
+- `default async function Image({ params })`
+
+### `src/app/opengraph-image.tsx` — home
+
+- `eyebrow: "Portfolio"`
+- `title: "Julian Suarez Vivas"`
+- `subtitle: "Full-stack web developer — Next.js, React, TypeScript"`
+
+### `src/app/(front)/project/[slug]/opengraph-image.tsx`
+
+- `eyebrow: "Project"`
+- `title: project.name`
+- `subtitle: truncate(project.description, 120)`
+- Footer shows the first 4 stack items as chips.
+
+### `src/app/experience/[slug]/opengraph-image.tsx`
+
+- `eyebrow: "Experience"`
+- `title: role`
+- `subtitle: company`
+- Footer shows the date range.
+
+Next auto-discovers these files and injects correct `og:image` URLs into each
+route's metadata — no manual wiring in the `generateMetadata` objects.
+
+## Sitemap — `src/app/sitemap.ts`
+
+Default export returning `MetadataRoute.Sitemap`:
+
+- `/` — priority `1.0`, `changeFrequency: "monthly"`.
+- `/archive` — priority `0.7`, `monthly`.
+- Each `/project/{slug}` from `sortedProjects` — priority `0.8`, `yearly`.
+- Each `/experience/{slug}` from `sortedExperiences` — priority `0.6`, `yearly`.
+- `lastModified: new Date()` at build time (data model has no per-entry modified
+  date; adding one is out of scope).
+- All URLs built via `absoluteUrl()`.
+
+## Robots — `src/app/robots.ts`
+
+Default export returning `MetadataRoute.Robots`:
+
+- If `isProductionHost(siteUrl)` → allow all, include sitemap + host.
+- Else → disallow all, no sitemap pointer.
+
+```ts
+if (isProductionHost(siteUrl)) {
+	return {
+		rules: [{ userAgent: "*", allow: "/" }],
+		sitemap: absoluteUrl("/sitemap.xml"),
+		host: "www.julisv.com",
+	};
+}
+return { rules: [{ userAgent: "*", disallow: "/" }] };
+```
+
+Closes the gap left by `lighthouserc.json`'s `is-crawlable: off` override.
+
+## Testing
+
+Vitest-based, narrow unit coverage on pure logic:
+
+- `src/lib/seo.test.ts`
+  - `absoluteUrl()` — builds correct URL from pathname; handles leading slash.
+  - `truncate()` — short string unchanged, long string truncated at word
+    boundary with ellipsis, empty string handled.
+  - `isProductionHost()` — `www.julisv.com` true; `preview.vercel.app`,
+    `localhost`, other hosts false.
+- `src/app/sitemap.test.ts`
+  - Output includes `/`, `/archive`, every project slug, every experience slug.
+  - Every URL starts with `https://www.julisv.com`.
+  - Count matches `sortedProjects.length + sortedExperiences.length + 2`.
+- `src/app/robots.test.ts`
+  - With `NEXT_PUBLIC_SITE_URL=https://www.julisv.com` → rules allow.
+  - With a preview URL → rules disallow and no sitemap field.
+  - Stubs env per test; no cross-test leakage.
+
+No tests for `opengraph-image.tsx` (visual — verify manually) or
+`generateMetadata` functions (thin data-plumbing — covered by the build).
+
+## Manual Verification
+
+1. `pnpm build` — surfaces `metadataBase` issues, OG runtime errors, missing
+   fonts.
+2. `pnpm start` — visit `/sitemap.xml` and `/robots.txt`, confirm shape.
+3. `/project/tailorsift` view-source — confirm `og:image`, `twitter:card`,
+   canonical, JSON-LD `CreativeWork` all present.
+4. Post-deploy: drop `https://www.julisv.com` and
+   `https://www.julisv.com/project/tailorsift` into the LinkedIn Post Inspector
+   and Twitter Card Validator; confirm OG images render.
+
+## Environment
+
+Set on Vercel:
+
+- **Production:** `NEXT_PUBLIC_SITE_URL=https://www.julisv.com`.
+- **Preview / development:** leave unset. `seo.ts` falls back to
+  `https://${VERCEL_URL}` on Vercel previews, `https://www.julisv.com` locally.
+  `isProductionHost` ensures only the real production host gets indexable
+  robots + sitemap.
+
+## Out of Scope
+
+- `lucide-react` `Github` / `Linkedin` deprecation warnings in `Header.tsx`
+  (unrelated to SEO).
+- Per-entry `lastModified` dates in project/experience data (low value).
+- `hreflang` / i18n (site is en-only).
+- Changes to PostHog / analytics.
+
+## File Changes Summary
+
+New files:
+
+- `src/lib/seo.ts`
+- `src/lib/seo.test.ts`
+- `src/lib/og-template.tsx`
+- `src/app/opengraph-image.tsx`
+- `src/app/(front)/project/[slug]/opengraph-image.tsx`
+- `src/app/experience/[slug]/opengraph-image.tsx`
+- `src/app/sitemap.ts`
+- `src/app/sitemap.test.ts`
+- `src/app/robots.ts`
+- `src/app/robots.test.ts`
+
+Modified files:
+
+- `src/app/layout.tsx` — full metadata + JSON-LD Person script.
+- `src/app/(front)/project/[slug]/page.tsx` — `generateMetadata` +
+  `CreativeWork` JSON-LD.
+- `src/app/experience/[slug]/page.tsx` — `generateMetadata`.
+- `src/app/(front)/archive/page.tsx` — static `metadata` export.

--- a/lighthouserc.production.json
+++ b/lighthouserc.production.json
@@ -1,0 +1,31 @@
+{
+	"ci": {
+		"collect": {
+			"numberOfRuns": 3,
+			"settings": {
+				"preset": "desktop",
+				"onlyCategories": [
+					"performance",
+					"accessibility",
+					"best-practices",
+					"seo"
+				]
+			}
+		},
+		"assert": {
+			"assertions": {
+				"categories:performance": ["error", { "minScore": 0.8 }],
+				"categories:accessibility": ["error", { "minScore": 0.9 }],
+				"categories:best-practices": ["error", { "minScore": 0.9 }],
+				"categories:seo": ["error", { "minScore": 0.9 }],
+				"first-contentful-paint": ["warn", { "maxNumericValue": 2000 }],
+				"largest-contentful-paint": ["warn", { "maxNumericValue": 2500 }],
+				"cumulative-layout-shift": ["warn", { "maxNumericValue": 0.1 }],
+				"total-blocking-time": ["warn", { "maxNumericValue": 300 }]
+			}
+		},
+		"upload": {
+			"target": "temporary-public-storage"
+		}
+	}
+}

--- a/src/app/(front)/archive/page.tsx
+++ b/src/app/(front)/archive/page.tsx
@@ -1,6 +1,27 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { sortedProjects } from "@/data";
+
+const ARCHIVE_DESCRIPTION =
+	"The complete archive of projects I've built — websites, web apps, and experiments.";
+
+export const metadata: Metadata = {
+	title: "Archive",
+	description: ARCHIVE_DESCRIPTION,
+	alternates: { canonical: "/archive" },
+	openGraph: {
+		type: "website",
+		url: "/archive",
+		title: "Archive",
+		description: ARCHIVE_DESCRIPTION,
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: "Archive",
+		description: ARCHIVE_DESCRIPTION,
+	},
+};
 
 const Archive = async () => {
 	const projects = sortedProjects;

--- a/src/app/(front)/project/[slug]/opengraph-image.tsx
+++ b/src/app/(front)/project/[slug]/opengraph-image.tsx
@@ -1,0 +1,37 @@
+import { ImageResponse } from "next/og";
+import { renderOgImage } from "@/lib/og-template";
+import { DEFAULT_OG_SIZE, truncate } from "@/lib/seo";
+import { getProjectBySlug, sortedProjects } from "@/data";
+
+export const runtime = "nodejs";
+export const alt = "Project preview";
+export const size = DEFAULT_OG_SIZE;
+export const contentType = "image/png";
+
+export async function generateStaticParams() {
+	return sortedProjects.map((p) => ({ slug: p.slug }));
+}
+
+interface ImageProps {
+	params: Promise<{ slug: string }>;
+}
+
+export default async function Image({ params }: ImageProps) {
+	const { slug } = await params;
+	const project = getProjectBySlug(slug);
+	const title = project?.title ?? "Project";
+	const subtitle = project
+		? truncate(project.description, 120)
+		: "Portfolio project";
+	const stackChips = project ? project.stack.slice(0, 4).join(" · ") : "";
+
+	return new ImageResponse(
+		renderOgImage({
+			eyebrow: "Project",
+			title,
+			subtitle,
+			footer: stackChips,
+		}),
+		{ ...DEFAULT_OG_SIZE }
+	);
+}

--- a/src/app/(front)/project/[slug]/page.tsx
+++ b/src/app/(front)/project/[slug]/page.tsx
@@ -1,10 +1,70 @@
+import type { Metadata } from "next";
 import SingleProject from "@/features/front/projects/components/SingleProject";
-import { sortedProjects } from "@/data";
+import { sortedProjects, getProjectBySlug } from "@/data";
+import { absoluteUrl, truncate } from "@/lib/seo";
 
-const ProjectPage = async (props: { params: Promise<{ slug: string }> }) => {
+interface PageProps {
+	params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+	params,
+}: PageProps): Promise<Metadata> {
+	const { slug } = await params;
+	const project = getProjectBySlug(slug);
+	if (!project) return {};
+
+	const description = truncate(project.description);
+	const canonical = `/project/${project.slug}`;
+
+	return {
+		title: project.title,
+		description,
+		keywords: project.stack,
+		alternates: { canonical },
+		openGraph: {
+			type: "article",
+			url: canonical,
+			title: project.title,
+			description,
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: project.title,
+			description,
+		},
+	};
+}
+
+const ProjectPage = async (props: PageProps) => {
 	const params = await props.params;
+	const project = getProjectBySlug(params.slug);
 
-	return <SingleProject slug={params.slug} />;
+	const jsonLd = project
+		? {
+				"@context": "https://schema.org",
+				"@type": "CreativeWork",
+				name: project.title,
+				description: project.description,
+				url: project.url,
+				author: { "@type": "Person", name: "Julian Suarez Vivas" },
+				keywords: project.stack.join(", "),
+				image: absoluteUrl(project.image),
+			}
+		: null;
+
+	return (
+		<>
+			{jsonLd ? (
+				<script
+					type="application/ld+json"
+					// JSON-LD content is compile-time (projects data); JSON.stringify handles escaping.
+					dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+				/>
+			) : null}
+			<SingleProject slug={params.slug} />
+		</>
+	);
 };
 
 export default ProjectPage;

--- a/src/app/experience/[slug]/opengraph-image.tsx
+++ b/src/app/experience/[slug]/opengraph-image.tsx
@@ -1,0 +1,37 @@
+import { ImageResponse } from "next/og";
+import { renderOgImage } from "@/lib/og-template";
+import { DEFAULT_OG_SIZE } from "@/lib/seo";
+import { getExperienceBySlug, sortedExperiences } from "@/data";
+
+export const runtime = "nodejs";
+export const alt = "Experience preview";
+export const size = DEFAULT_OG_SIZE;
+export const contentType = "image/png";
+
+export async function generateStaticParams() {
+	return sortedExperiences.map((e) => ({ slug: e.slug }));
+}
+
+interface ImageProps {
+	params: Promise<{ slug: string }>;
+}
+
+export default async function Image({ params }: ImageProps) {
+	const { slug } = await params;
+	const experience = getExperienceBySlug(slug);
+	const title = experience?.position ?? "Experience";
+	const subtitle = experience?.company ?? "";
+	const dateRange = experience
+		? `${experience.startDate} — ${experience.endDate}`
+		: "";
+
+	return new ImageResponse(
+		renderOgImage({
+			eyebrow: "Experience",
+			title,
+			subtitle,
+			footer: dateRange,
+		}),
+		{ ...DEFAULT_OG_SIZE }
+	);
+}

--- a/src/app/experience/[slug]/page.tsx
+++ b/src/app/experience/[slug]/page.tsx
@@ -1,9 +1,43 @@
+import type { Metadata } from "next";
 import ExperienceDetail from "@/features/front/experience/components/ExperienceDetail";
-import { sortedExperiences } from "@/data";
+import { sortedExperiences, getExperienceBySlug } from "@/data";
+import { truncate } from "@/lib/seo";
 
-const ExperiencePage = async (props: { params: Promise<{ slug: string }> }) => {
+interface PageProps {
+	params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+	params,
+}: PageProps): Promise<Metadata> {
+	const { slug } = await params;
+	const experience = getExperienceBySlug(slug);
+	if (!experience) return {};
+
+	const title = `${experience.position} at ${experience.company}`;
+	const description = truncate(experience.description);
+	const canonical = `/experience/${experience.slug}`;
+
+	return {
+		title,
+		description,
+		alternates: { canonical },
+		openGraph: {
+			type: "article",
+			url: canonical,
+			title,
+			description,
+		},
+		twitter: {
+			card: "summary_large_image",
+			title,
+			description,
+		},
+	};
+}
+
+const ExperiencePage = async (props: PageProps) => {
 	const params = await props.params;
-
 	return <ExperienceDetail slug={params.slug} />;
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,16 +2,49 @@ import type { Metadata } from "next";
 import { Montserrat } from "next/font/google";
 import "./globals.css";
 import { PostHogProvider } from "../providers/ph-provider";
+import { siteUrl, absoluteUrl } from "@/lib/seo";
+import { siteConfig } from "@/data/site";
+
+const DESCRIPTION =
+	"Full-stack web developer specializing in Next.js, React, and TypeScript. Building fast, accessible, and well-crafted web experiences.";
 
 export const metadata: Metadata = {
-	title: "Julian Suarez Vivas",
-	description:
-		"Full-stack web developer specializing in Next.js, React, and TypeScript. Building fast, accessible, and well-crafted web experiences.",
+	metadataBase: siteUrl,
+	title: {
+		default: `${siteConfig.name} — Full-stack web developer`,
+		template: `%s · ${siteConfig.name}`,
+	},
+	description: DESCRIPTION,
+	authors: [{ name: siteConfig.name, url: siteUrl.toString() }],
+	alternates: { canonical: "/" },
+	openGraph: {
+		type: "website",
+		url: "/",
+		siteName: siteConfig.name,
+		locale: "en_US",
+		title: `${siteConfig.name} — Full-stack web developer`,
+		description: DESCRIPTION,
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: `${siteConfig.name} — Full-stack web developer`,
+		description: DESCRIPTION,
+	},
+	robots: { index: true, follow: true },
 };
 
 const montserrat = Montserrat({
 	subsets: ["latin"],
 });
+
+const personJsonLd = {
+	"@context": "https://schema.org",
+	"@type": "Person",
+	name: siteConfig.name,
+	url: absoluteUrl("/"),
+	jobTitle: "Full-stack web developer",
+	sameAs: [siteConfig.socialLinks.github, siteConfig.socialLinks.linkedin],
+};
 
 export default function RootLayout({
 	children,
@@ -21,6 +54,11 @@ export default function RootLayout({
 	return (
 		<html lang="en" className={`scroll-smooth ` + montserrat.className}>
 			<body className="bg-dark-purple leading-relaxed text-slate-400 antialiased selection:bg-sky-400 selection:text-slate-900">
+				<script
+					type="application/ld+json"
+					// JSON-LD content is compile-time (siteConfig); JSON.stringify handles escaping.
+					dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+				/>
 				<PostHogProvider>{children}</PostHogProvider>
 			</body>
 		</html>

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,20 @@
+import { ImageResponse } from "next/og";
+import { renderOgImage } from "@/lib/og-template";
+import { DEFAULT_OG_SIZE } from "@/lib/seo";
+import { siteConfig } from "@/data/site";
+
+export const runtime = "nodejs";
+export const alt = `${siteConfig.name} — Full-stack web developer`;
+export const size = DEFAULT_OG_SIZE;
+export const contentType = "image/png";
+
+export default async function Image() {
+	return new ImageResponse(
+		renderOgImage({
+			eyebrow: "Portfolio",
+			title: siteConfig.name,
+			subtitle: "Full-stack web developer — Next.js, React, TypeScript",
+		}),
+		{ ...DEFAULT_OG_SIZE }
+	);
+}

--- a/src/app/robots.test.ts
+++ b/src/app/robots.test.ts
@@ -35,4 +35,14 @@ describe("robots()", () => {
 		const result = robots();
 		expect(result.rules).toEqual([{ userAgent: "*", disallow: "/" }]);
 	});
+
+	it("allows crawling when neither env var is set (pure default fallback)", async () => {
+		delete process.env.NEXT_PUBLIC_SITE_URL;
+		delete process.env.VERCEL_URL;
+		const robots = (await import("./robots")).default;
+		const result = robots();
+		expect(result.rules).toEqual([{ userAgent: "*", allow: "/" }]);
+		expect(result.sitemap).toBe("https://www.julisv.com/sitemap.xml");
+		expect(result.host).toBe("www.julisv.com");
+	});
 });

--- a/src/app/robots.test.ts
+++ b/src/app/robots.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+describe("robots()", () => {
+	const ORIGINAL_ENV = { ...process.env };
+
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		process.env = { ...ORIGINAL_ENV };
+	});
+
+	it("allows all crawling on production host and includes sitemap", async () => {
+		process.env.NEXT_PUBLIC_SITE_URL = "https://www.julisv.com";
+		const robots = (await import("./robots")).default;
+		const result = robots();
+		expect(result.rules).toEqual([{ userAgent: "*", allow: "/" }]);
+		expect(result.sitemap).toBe("https://www.julisv.com/sitemap.xml");
+		expect(result.host).toBe("www.julisv.com");
+	});
+
+	it("disallows all crawling on preview host and omits sitemap", async () => {
+		process.env.NEXT_PUBLIC_SITE_URL = "https://preview.vercel.app";
+		const robots = (await import("./robots")).default;
+		const result = robots();
+		expect(result.rules).toEqual([{ userAgent: "*", disallow: "/" }]);
+		expect(result.sitemap).toBeUndefined();
+	});
+
+	it("disallows all crawling when siteUrl falls back to VERCEL_URL", async () => {
+		delete process.env.NEXT_PUBLIC_SITE_URL;
+		process.env.VERCEL_URL = "my-preview.vercel.app";
+		const robots = (await import("./robots")).default;
+		const result = robots();
+		expect(result.rules).toEqual([{ userAgent: "*", disallow: "/" }]);
+	});
+});

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
 		return {
 			rules: [{ userAgent: "*", allow: "/" }],
 			sitemap: absoluteUrl("/sitemap.xml"),
-			host: "www.julisv.com",
+			host: siteUrl.host,
 		};
 	}
 	return {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+import { siteUrl, isProductionHost, absoluteUrl } from "@/lib/seo";
+
+export default function robots(): MetadataRoute.Robots {
+	if (isProductionHost(siteUrl)) {
+		return {
+			rules: [{ userAgent: "*", allow: "/" }],
+			sitemap: absoluteUrl("/sitemap.xml"),
+			host: "www.julisv.com",
+		};
+	}
+	return {
+		rules: [{ userAgent: "*", disallow: "/" }],
+	};
+}

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { sortedProjects } from "@/data/projects";
+import { sortedExperiences } from "@/data/experience";
+
+describe("sitemap()", () => {
+	const ORIGINAL_ENV = { ...process.env };
+
+	beforeEach(() => {
+		vi.resetModules();
+		process.env.NEXT_PUBLIC_SITE_URL = "https://www.julisv.com";
+	});
+
+	afterEach(() => {
+		process.env = { ...ORIGINAL_ENV };
+	});
+
+	it("includes home, archive, all projects, and all experiences", async () => {
+		const sitemap = (await import("./sitemap")).default;
+		const entries = sitemap();
+
+		const urls = entries.map((e) => e.url);
+		expect(urls).toContain("https://www.julisv.com/");
+		expect(urls).toContain("https://www.julisv.com/archive");
+		for (const p of sortedProjects) {
+			expect(urls).toContain(`https://www.julisv.com/project/${p.slug}`);
+		}
+		for (const e of sortedExperiences) {
+			expect(urls).toContain(`https://www.julisv.com/experience/${e.slug}`);
+		}
+	});
+
+	it("has the expected total count", async () => {
+		const sitemap = (await import("./sitemap")).default;
+		const entries = sitemap();
+		expect(entries.length).toBe(
+			sortedProjects.length + sortedExperiences.length + 2
+		);
+	});
+
+	it("all urls start with the configured site url", async () => {
+		const sitemap = (await import("./sitemap")).default;
+		const entries = sitemap();
+		for (const e of entries) {
+			expect(e.url.startsWith("https://www.julisv.com/")).toBe(true);
+		}
+	});
+
+	it("every entry has a lastModified date", async () => {
+		const sitemap = (await import("./sitemap")).default;
+		const entries = sitemap();
+		for (const e of entries) {
+			expect(e.lastModified).toBeInstanceOf(Date);
+		}
+	});
+});

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,41 @@
+import type { MetadataRoute } from "next";
+import { absoluteUrl } from "@/lib/seo";
+import { sortedProjects } from "@/data/projects";
+import { sortedExperiences } from "@/data/experience";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+	const now = new Date();
+
+	const staticEntries: MetadataRoute.Sitemap = [
+		{
+			url: absoluteUrl("/"),
+			lastModified: now,
+			changeFrequency: "monthly",
+			priority: 1,
+		},
+		{
+			url: absoluteUrl("/archive"),
+			lastModified: now,
+			changeFrequency: "monthly",
+			priority: 0.7,
+		},
+	];
+
+	const projectEntries: MetadataRoute.Sitemap = sortedProjects.map((p) => ({
+		url: absoluteUrl(`/project/${p.slug}`),
+		lastModified: now,
+		changeFrequency: "yearly",
+		priority: 0.8,
+	}));
+
+	const experienceEntries: MetadataRoute.Sitemap = sortedExperiences.map(
+		(e) => ({
+			url: absoluteUrl(`/experience/${e.slug}`),
+			lastModified: now,
+			changeFrequency: "yearly",
+			priority: 0.6,
+		})
+	);
+
+	return [...staticEntries, ...projectEntries, ...experienceEntries];
+}

--- a/src/lib/og-template.tsx
+++ b/src/lib/og-template.tsx
@@ -1,0 +1,88 @@
+import type { ReactElement } from "react";
+
+interface OgTemplateProps {
+	eyebrow: string;
+	title: string;
+	subtitle: string;
+	footer?: string | ReactElement;
+}
+
+const DARK_PURPLE = "#0a0a23";
+const SKY_400 = "#38bdf8";
+const SLATE_100 = "#f1f5f9";
+const SLATE_400 = "#94a3b8";
+
+export function renderOgImage({
+	eyebrow,
+	title,
+	subtitle,
+	footer,
+}: OgTemplateProps): ReactElement {
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				justifyContent: "space-between",
+				backgroundColor: DARK_PURPLE,
+				padding: "80px",
+				color: SLATE_100,
+				fontFamily: "sans-serif",
+			}}
+		>
+			<div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
+				<div style={{ display: "flex", alignItems: "center", gap: "16px" }}>
+					<div
+						style={{ width: "48px", height: "4px", backgroundColor: SKY_400 }}
+					/>
+					<span
+						style={{
+							fontSize: "24px",
+							textTransform: "uppercase",
+							letterSpacing: "4px",
+							color: SKY_400,
+						}}
+					>
+						{eyebrow}
+					</span>
+				</div>
+				<h1
+					style={{
+						fontSize: "84px",
+						lineHeight: 1.05,
+						fontWeight: 700,
+						margin: 0,
+						maxWidth: "1000px",
+					}}
+				>
+					{title}
+				</h1>
+				<p
+					style={{
+						fontSize: "36px",
+						lineHeight: 1.3,
+						color: SLATE_400,
+						margin: 0,
+						maxWidth: "1000px",
+					}}
+				>
+					{subtitle}
+				</p>
+			</div>
+			<div
+				style={{
+					display: "flex",
+					justifyContent: "space-between",
+					alignItems: "flex-end",
+					fontSize: "24px",
+					color: SLATE_400,
+				}}
+			>
+				<span style={{ display: "flex" }}>julisv.com</span>
+				{footer ? <span style={{ display: "flex" }}>{footer}</span> : null}
+			</div>
+		</div>
+	);
+}

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -93,6 +93,16 @@ describe("seo primitives", () => {
 			const { truncate } = await import("./seo");
 			expect(truncate("", 160)).toBe("");
 		});
+
+		it("hard-cuts mid-word when the last space is too far back", async () => {
+			const { truncate } = await import("./seo");
+			// Space only at index 2; with max=15 the threshold is 9, so lastSpace(2) < 9.
+			const out = truncate("ab cdefghijklmnopqrst", 15);
+			expect(out.length).toBeLessThanOrEqual(15);
+			expect(out.endsWith("…")).toBe(true);
+			// Confirms mid-word cut, not early-space cut.
+			expect(out).not.toBe("ab…");
+		});
 	});
 
 	describe("DEFAULT_OG_SIZE", () => {

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+describe("seo primitives", () => {
+	const ORIGINAL_ENV = { ...process.env };
+
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		process.env = { ...ORIGINAL_ENV };
+	});
+
+	describe("siteUrl", () => {
+		it("uses NEXT_PUBLIC_SITE_URL when set", async () => {
+			process.env.NEXT_PUBLIC_SITE_URL = "https://example.com";
+			const { siteUrl } = await import("./seo");
+			expect(siteUrl.toString()).toBe("https://example.com/");
+		});
+
+		it("falls back to https://VERCEL_URL when only VERCEL_URL is set", async () => {
+			delete process.env.NEXT_PUBLIC_SITE_URL;
+			process.env.VERCEL_URL = "my-preview.vercel.app";
+			const { siteUrl } = await import("./seo");
+			expect(siteUrl.toString()).toBe("https://my-preview.vercel.app/");
+		});
+
+		it("falls back to https://www.julisv.com when neither env var is set", async () => {
+			delete process.env.NEXT_PUBLIC_SITE_URL;
+			delete process.env.VERCEL_URL;
+			const { siteUrl } = await import("./seo");
+			expect(siteUrl.toString()).toBe("https://www.julisv.com/");
+		});
+	});
+
+	describe("absoluteUrl", () => {
+		it("builds an absolute URL from a pathname with leading slash", async () => {
+			process.env.NEXT_PUBLIC_SITE_URL = "https://www.julisv.com";
+			const { absoluteUrl } = await import("./seo");
+			expect(absoluteUrl("/project/tailorsift")).toBe(
+				"https://www.julisv.com/project/tailorsift"
+			);
+		});
+
+		it("handles the root path", async () => {
+			process.env.NEXT_PUBLIC_SITE_URL = "https://www.julisv.com";
+			const { absoluteUrl } = await import("./seo");
+			expect(absoluteUrl("/")).toBe("https://www.julisv.com/");
+		});
+	});
+
+	describe("isProductionHost", () => {
+		it("returns true for www.julisv.com", async () => {
+			const { isProductionHost } = await import("./seo");
+			expect(isProductionHost(new URL("https://www.julisv.com"))).toBe(true);
+		});
+
+		it("returns false for preview host", async () => {
+			const { isProductionHost } = await import("./seo");
+			expect(isProductionHost(new URL("https://preview.vercel.app"))).toBe(
+				false
+			);
+		});
+
+		it("returns false for localhost", async () => {
+			const { isProductionHost } = await import("./seo");
+			expect(isProductionHost(new URL("http://localhost:3000"))).toBe(false);
+		});
+
+		it("returns false for apex julisv.com (no www)", async () => {
+			const { isProductionHost } = await import("./seo");
+			expect(isProductionHost(new URL("https://julisv.com"))).toBe(false);
+		});
+	});
+
+	describe("truncate", () => {
+		it("returns the input unchanged when shorter than max", async () => {
+			const { truncate } = await import("./seo");
+			expect(truncate("short", 160)).toBe("short");
+		});
+
+		it("truncates at word boundary and appends ellipsis", async () => {
+			const { truncate } = await import("./seo");
+			const input =
+				"This is a long description that will definitely exceed the limit when we set the limit low enough to see truncation";
+			const out = truncate(input, 40);
+			expect(out.length).toBeLessThanOrEqual(40);
+			expect(out.endsWith("…")).toBe(true);
+			expect(out).not.toContain("  ");
+		});
+
+		it("handles empty string", async () => {
+			const { truncate } = await import("./seo");
+			expect(truncate("", 160)).toBe("");
+		});
+	});
+
+	describe("DEFAULT_OG_SIZE", () => {
+		it("is 1200x630", async () => {
+			const { DEFAULT_OG_SIZE } = await import("./seo");
+			expect(DEFAULT_OG_SIZE).toEqual({ width: 1200, height: 630 });
+		});
+	});
+});

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,4 +1,5 @@
 const DEFAULT_SITE_URL = "https://www.julisv.com";
+const PRODUCTION_HOST = new URL(DEFAULT_SITE_URL).host;
 
 function resolveSiteUrl(): URL {
 	const explicit = process.env.NEXT_PUBLIC_SITE_URL;
@@ -15,7 +16,7 @@ export const siteUrl: URL = resolveSiteUrl();
 export const DEFAULT_OG_SIZE = { width: 1200, height: 630 } as const;
 
 export function isProductionHost(url: URL): boolean {
-	return url.host === "www.julisv.com";
+	return url.host === PRODUCTION_HOST;
 }
 
 export function absoluteUrl(path: string): string {

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,31 @@
+const DEFAULT_SITE_URL = "https://www.julisv.com";
+
+function resolveSiteUrl(): URL {
+	const explicit = process.env.NEXT_PUBLIC_SITE_URL;
+	if (explicit) return new URL(explicit);
+
+	const vercel = process.env.VERCEL_URL;
+	if (vercel) return new URL(`https://${vercel}`);
+
+	return new URL(DEFAULT_SITE_URL);
+}
+
+export const siteUrl: URL = resolveSiteUrl();
+
+export const DEFAULT_OG_SIZE = { width: 1200, height: 630 } as const;
+
+export function isProductionHost(url: URL): boolean {
+	return url.host === "www.julisv.com";
+}
+
+export function absoluteUrl(path: string): string {
+	return new URL(path, siteUrl).toString();
+}
+
+export function truncate(str: string, max = 160): string {
+	if (str.length <= max) return str;
+	const sliced = str.slice(0, max - 1);
+	const lastSpace = sliced.lastIndexOf(" ");
+	const cut = lastSpace > max * 0.6 ? sliced.slice(0, lastSpace) : sliced;
+	return `${cut.trimEnd()}…`;
+}


### PR DESCRIPTION
## Summary

Adds a complete SEO foundation for the portfolio:

- **Per-route metadata** on `/`, `/archive`, `/project/[slug]`, `/experience/[slug]` — title template, canonical, OG, Twitter cards, keywords.
- **Dynamic OG images** (1200×630) rendered via `next/og` `ImageResponse` for home, each project, each experience — shared `renderOgImage` template.
- **`sitemap.xml`** — home, archive, all projects, all experiences.
- **`robots.txt`** — allow on production host, disallow on previews (closes the gap that `lighthouserc.json`'s `is-crawlable: off` was masking).
- **JSON-LD structured data** — `Person` on root layout, `CreativeWork` per project.
- **Shared primitives** in `src/lib/seo.ts` — `siteUrl` singleton (reads `NEXT_PUBLIC_SITE_URL` → `VERCEL_URL` → default), `isProductionHost`, `absoluteUrl`, `truncate`, `DEFAULT_OG_SIZE`. 22 unit tests.
- **Lighthouse CI split** — production config enforces `is-crawlable`; preview keeps it suppressed since previews intentionally return `Disallow: /`.

Env var: `NEXT_PUBLIC_SITE_URL=https://www.julisv.com` is set on Vercel production (unset on preview → falls back to `VERCEL_URL` so robots correctly disallows).

Spec: `docs/superpowers/specs/2026-04-21-seo-improvements-design.md`
Plan: `docs/superpowers/plans/2026-04-21-seo-improvements.md`

## Test plan

- [x] `pnpm validate` (lint, typecheck, 59 tests, build)
- [x] Local `pnpm start` — `/robots.txt` and `/sitemap.xml` render correctly
- [x] `/project/tailorsift` view-source shows canonical, og:image, twitter:card, Person + CreativeWork JSON-LD
- [x] Home page shows `<title>Julian Suarez Vivas — Full-stack web developer</title>` and Person JSON-LD
- [ ] Post-merge: LinkedIn Post Inspector on home + a project URL
- [ ] Post-merge: Twitter Card Validator on home + a project URL
- [ ] Post-merge: Google Rich Results Test detects `Person` on home and `CreativeWork` on `/project/tailorsift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)