### PR TITLE
feat(projects): refine featured hero card layout and tailorsift copy

### DIFF
--- a/docs/superpowers/plans/2026-04-23-featured-hero-card-refinement.md
+++ b/docs/superpowers/plans/2026-04-23-featured-hero-card-refinement.md
@@ -1,0 +1,489 @@
+# Featured Hero Card Refinement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restructure the `FeaturedHeroProject` card into a two-row layout
+(image+summary on top, chips+Visit-site CTA on a full-width bottom row), make
+the entire card clickable to the project detail page, match the grid cards'
+extended hover affordance, and update the Tailorsift description copy.
+
+**Architecture:** One React component is modified in place
+(`FeaturedHeroProject.tsx`). A hover-background sibling is added — mirroring the
+pattern already used in `Projects.tsx` — so the two card families share visual
+behavior. The title `ViewTransitionLink` becomes the single route anchor; its
+absolute-span trick extends the click target across the whole card. The external
+"Visit site" anchor sits on a higher stacking context so it remains
+independently clickable. One data file (`tailorsift.ts`) gets a one-line
+description update. Unit tests in `FeaturedHeroProject.test.tsx` are updated to
+cover the new markup and prevent regression of the removed "View project" link.
+
+**Tech Stack:** Next.js 15 (App Router), React 19, TypeScript strict, Tailwind
+CSS v4, Vitest + @testing-library/react.
+
+---
+
+## File Structure
+
+**Create:** none
+
+**Modify:**
+
+- `src/features/front/projects/components/FeaturedHeroProject.tsx` — two-row
+  layout, extended-hover sibling, title becomes full-card link, drop "View
+  <title> project" link.
+- `src/features/front/projects/components/FeaturedHeroProject.test.tsx` — update
+  existing assertions, add new ones, remove the assertion for the deleted text
+  link.
+- `src/data/projects/tailorsift.ts` — replace the `description` string.
+
+Each modification is self-contained; the three files can be touched in one TDD
+cycle but are split into separate tasks below so each commit stays focused.
+
+---
+
+## Task 1: Update Tailorsift description copy
+
+**Files:**
+
+- Modify: `src/data/projects/tailorsift.ts:10-11`
+
+- [ ] **Step 1: Update the description string**
+
+In `src/data/projects/tailorsift.ts`, replace the `description` value. Exact old
+and new strings:
+
+Old:
+
+```ts
+description:
+    "AI-powered job hunt platform that sifts roles and tailors CVs, cover letters, and interview prep to each listing.",
+```
+
+New:
+
+```ts
+description:
+    "AI-powered job hunt platform that helps individuals sift roles and tailor CVs, cover letters, and interview prep to each opportunity.",
+```
+
+Nothing else in that file changes.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/data/projects/tailorsift.ts
+git commit -m "feat(projects): refine tailorsift description copy"
+```
+
+---
+
+## Task 2: Update the failing tests for the new card markup
+
+**Files:**
+
+- Modify: `src/features/front/projects/components/FeaturedHeroProject.test.tsx`
+
+This task locks in the expected behavior of the new component before any
+implementation change. It will leave the test file red until Task 3 makes it
+pass.
+
+- [ ] **Step 1: Replace the whole test file with the updated version**
+
+Write this exact content to
+`src/features/front/projects/components/FeaturedHeroProject.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FeaturedHeroProject } from "./FeaturedHeroProject";
+import type { Project } from "@/data/types";
+
+vi.mock("next/image", () => ({
+	default: ({ src, alt }: { src: string; alt: string }) => (
+		<img src={src} alt={alt} />
+	),
+}));
+
+vi.mock("@/components/ViewTransitionLink", () => ({
+	ViewTransitionLink: ({
+		children,
+		href,
+		...props
+	}: {
+		children: React.ReactNode;
+		href: string;
+	}) => (
+		<a href={href} {...props}>
+			{children}
+		</a>
+	),
+}));
+
+const project: Project = {
+	id: "9",
+	slug: "tailorsift",
+	title: "TailorSift",
+	year: 2026,
+	featured: true,
+	hero: true,
+	description: "AI-powered job hunt platform.",
+	longDescription: "<p>Long.</p>",
+	features: ["AI fit analysis"],
+	technologies: ["Next.js", "TypeScript"],
+	stack: ["Next.js", "TypeScript", "Supabase", "AI"],
+	image: "/images/projects/tailorsift.webp",
+	url: "https://tailorsift.io",
+};
+
+describe("FeaturedHeroProject", () => {
+	it("renders the project title", () => {
+		render(<FeaturedHeroProject project={project} />);
+		expect(screen.getByText("TailorSift")).toBeInTheDocument();
+	});
+
+	it("renders the tagline", () => {
+		render(<FeaturedHeroProject project={project} />);
+		expect(
+			screen.getByText("Sift the roles. Tailor the approach.")
+		).toBeInTheDocument();
+	});
+
+	it("renders the description", () => {
+		render(<FeaturedHeroProject project={project} />);
+		expect(
+			screen.getByText("AI-powered job hunt platform.")
+		).toBeInTheDocument();
+	});
+
+	it("renders all stack chips", () => {
+		render(<FeaturedHeroProject project={project} />);
+		project.stack.forEach((chip) => {
+			expect(screen.getByText(chip)).toBeInTheDocument();
+		});
+	});
+
+	it("renders the screenshot with correct src and alt", () => {
+		render(<FeaturedHeroProject project={project} />);
+		const img = screen.getByRole("img");
+		expect(img).toHaveAttribute("src", "/images/projects/tailorsift.webp");
+		expect(img.getAttribute("alt")).toMatch(/Screenshot of TailorSift/i);
+	});
+
+	it("renders external Visit site link with correct attributes", () => {
+		render(<FeaturedHeroProject project={project} />);
+		const link = screen.getByRole("link", {
+			name: /visit tailorsift live site/i,
+		});
+		expect(link).toHaveAttribute("href", "https://tailorsift.io");
+		expect(link).toHaveAttribute("target", "_blank");
+		expect(link).toHaveAttribute("rel", "noopener noreferrer");
+	});
+
+	it("links the title to the project detail page", () => {
+		render(<FeaturedHeroProject project={project} />);
+		const titleLink = screen
+			.getByRole("heading", { level: 3, name: /tailorsift/i })
+			.querySelector("a");
+		expect(titleLink).not.toBeNull();
+		expect(titleLink).toHaveAttribute("href", "/project/tailorsift");
+	});
+
+	it('does not render the removed "View <title> project" link', () => {
+		render(<FeaturedHeroProject project={project} />);
+		expect(
+			screen.queryByRole("link", { name: /view tailorsift project/i })
+		).not.toBeInTheDocument();
+	});
+
+	it("renders exactly two links: the title link and the Visit site link", () => {
+		render(<FeaturedHeroProject project={project} />);
+		const links = screen.getAllByRole("link");
+		expect(links).toHaveLength(2);
+		const hrefs = links.map((l) => l.getAttribute("href")).sort();
+		expect(hrefs).toEqual(["/project/tailorsift", "https://tailorsift.io"]);
+	});
+});
+```
+
+Key changes from the previous file:
+
+- Replaced the assertion that looked for a link with accessible name "view
+  tailorsift project" (text link) with an assertion that the **title** is the
+  link to `/project/tailorsift`.
+- Added an explicit negative assertion that the "View <title> project" text link
+  is gone.
+- Added an exact-count assertion: two links only (title + Visit site).
+
+- [ ] **Step 2: Run the tests to confirm they fail against the current
+      component**
+
+Run:
+`pnpm test src/features/front/projects/components/FeaturedHeroProject.test.tsx`
+
+Expected: the new test `does not render the removed "View <title> project" link`
+FAILS (the current component still renders that link). The test
+`renders exactly two links...` also FAILS for the same reason (it sees 3 links).
+The title-link assertion may pass coincidentally since the title is already
+wrapped in a link today — that is fine.
+
+Do **not** commit yet — the tree is red on purpose.
+
+---
+
+## Task 3: Restructure the component to match the design
+
+**Files:**
+
+- Modify: `src/features/front/projects/components/FeaturedHeroProject.tsx` (full
+  replace)
+
+- [ ] **Step 1: Replace the whole component file**
+
+Write this exact content to
+`src/features/front/projects/components/FeaturedHeroProject.tsx`:
+
+```tsx
+import { ProjectImage } from "@/components/ProjectImage";
+import { ArrowUpRight } from "lucide-react";
+import { ViewTransitionLink } from "@/components/ViewTransitionLink";
+import type { Project } from "@/data/types";
+
+interface FeaturedHeroProjectProps {
+	project: Project;
+}
+
+export const FeaturedHeroProject = ({ project }: FeaturedHeroProjectProps) => {
+	return (
+		<section
+			className="group relative mb-12 rounded-lg p-5 ring-1 ring-sky-400/20 transition md:p-6"
+			aria-labelledby={`hero-project-${project.slug}-title`}
+		>
+			<div className="absolute -inset-x-4 -inset-y-4 z-0 hidden rounded-md transition motion-reduce:transition-none lg:-inset-x-6 lg:block lg:group-hover:bg-slate-800/50 lg:group-hover:shadow-[inset_0_1px_0_0_rgba(148,163,184,0.1)] lg:group-hover:drop-shadow-lg" />
+
+			<div className="relative z-10 grid gap-6 sm:grid-cols-5 sm:gap-8">
+				<div
+					className="sm:col-span-2"
+					style={{ viewTransitionName: `project-image-${project.slug}` }}
+				>
+					<ProjectImage
+						src={project.image}
+						alt={`Screenshot of ${project.title} - ${project.description.slice(0, 100)}`}
+						width={400}
+						height={250}
+						className="w-full rounded border-2 border-slate-200/10 transition group-hover:border-slate-200/30"
+					/>
+				</div>
+				<div className="sm:col-span-3">
+					<h3
+						id={`hero-project-${project.slug}-title`}
+						className="text-xl font-semibold text-slate-200"
+					>
+						<ViewTransitionLink
+							href={`/project/${project.slug}`}
+							className="group/link inline-flex items-baseline text-slate-200 transition hover:text-sky-400 focus-visible:text-sky-400"
+						>
+							<span className="absolute -inset-x-4 -inset-y-4 hidden rounded-md lg:-inset-x-6 lg:block" />
+							<span
+								className="inline-block"
+								style={{
+									viewTransitionName: `project-title-${project.slug}`,
+								}}
+							>
+								{project.title}
+							</span>
+						</ViewTransitionLink>
+					</h3>
+					<p className="mt-1 text-sm font-medium text-sky-400">
+						Sift the roles. Tailor the approach.
+					</p>
+					<p className="mt-3 text-sm leading-normal text-slate-400">
+						{project.description}
+					</p>
+				</div>
+			</div>
+
+			<div className="relative z-10 mt-5 flex flex-wrap items-center justify-between gap-4">
+				{project.stack && (
+					<ul className="flex flex-wrap gap-2">
+						{project.stack.map((stackName) => (
+							<li key={stackName}>
+								<div className="flex items-center rounded-full bg-sky-400/10 px-3 py-1 text-xs font-medium leading-5 text-sky-400">
+									{stackName}
+								</div>
+							</li>
+						))}
+					</ul>
+				)}
+				<a
+					href={project.url}
+					target="_blank"
+					rel="noopener noreferrer"
+					aria-label={`Visit ${project.title} live site (opens in new tab)`}
+					className="relative z-20 inline-flex items-center gap-1 rounded-md bg-sky-400/10 px-3 py-1.5 text-sm font-medium text-sky-400 transition hover:bg-sky-400/20"
+				>
+					Visit site
+					<ArrowUpRight className="h-4 w-4" />
+				</a>
+			</div>
+		</section>
+	);
+};
+```
+
+Key differences versus the current component:
+
+- Removed `hover:bg-slate-800/30` from the `<section>` (superseded by the new
+  sibling).
+- Added the hover-bg sibling `<div>` directly inside the `<section>`, with `z-0`
+  and the `lg:group-hover:*` classes copied from `Projects.tsx`.
+- Wrapped the top grid and the bottom row in containers with `relative z-10` so
+  they sit above the hover-bg sibling.
+- Title now wraps in a `ViewTransitionLink`. The inner absolutely-positioned
+  `<span>` covers the whole `<section>` on `≥lg`, making the whole card a click
+  target on those breakpoints. The original inner `<span>` that carries
+  `viewTransitionName` is preserved verbatim.
+- Removed the trailing `ViewTransitionLink` whose accessible name was "View
+  <title> project".
+- Stack chips and the "Visit site" anchor now live in a single bottom flex row
+  (`justify-between`), both at `relative z-10`; the anchor is `z-20` to outrank
+  the title's hit-area span.
+
+- [ ] **Step 2: Run the component tests**
+
+Run:
+`pnpm test src/features/front/projects/components/FeaturedHeroProject.test.tsx`
+
+Expected: all 9 tests pass.
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm typecheck`
+
+Expected: no errors.
+
+- [ ] **Step 4: Run lint**
+
+Run: `pnpm lint`
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit the component + test changes together**
+
+```bash
+git add \
+  src/features/front/projects/components/FeaturedHeroProject.tsx \
+  src/features/front/projects/components/FeaturedHeroProject.test.tsx
+git commit -m "feat(projects): restructure featured hero card layout and hover"
+```
+
+---
+
+## Task 4: Manual verification in the browser
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `pnpm dev`
+
+Expected: server listening on `http://localhost:3000` (or next free port up to
+3003).
+
+- [ ] **Step 2: Verify the home page hero card on `≥lg`**
+
+Open `http://localhost:3000/` in a browser window at least 1024px wide. Check,
+in order:
+
+1. Hero card shows image (left), title + tagline + description (right), chips +
+   "Visit site" (full-width row underneath, one line).
+2. Hovering anywhere on the card produces a background tint that visually
+   extends beyond the card's padding (same effect as the project grid cards
+   below it).
+3. Hovering the title turns it sky-400.
+4. Clicking empty space on the card (e.g., below the description) navigates to
+   `/project/tailorsift`.
+5. Clicking "Visit site" opens `https://tailorsift.io` in a new tab, and does
+   **not** navigate the underlying page.
+6. Tab key: focus moves through two stops on the hero card — first the title
+   link, then "Visit site". Both show a visible focus ring.
+
+- [ ] **Step 3: Verify narrow viewport behavior**
+
+Resize the window to ~400px wide (or toggle mobile preview in DevTools). Check:
+
+1. Image stacks on top, summary below (existing behavior, unchanged).
+2. Chips row and "Visit site" still live in one flex container — if they don't
+   fit, the button wraps to its own line cleanly (no overflow).
+3. No horizontal scrollbar appears.
+4. Hover extension is absent below `lg` (by design — consistent with grid
+   cards).
+
+- [ ] **Step 4: Verify the description copy**
+
+Still on `/`, confirm the hero card reads:
+
+> "AI-powered job hunt platform that helps individuals sift roles and tailor
+> CVs, cover letters, and interview prep to each opportunity."
+
+Navigate to `/project/tailorsift`. The same description should appear there.
+
+- [ ] **Step 5: Console check**
+
+Open DevTools → Console. Expected: no red errors and no Next.js warnings about
+`priority`/`loading`, missing keys, or invalid `<a>` nesting.
+
+- [ ] **Step 6: Stop the dev server**
+
+Stop the `pnpm dev` process (Ctrl+C in the terminal running it).
+
+---
+
+## Task 5: Full validation and push
+
+**Files:** none
+
+- [ ] **Step 1: Run the full validation suite**
+
+Run: `pnpm validate`
+
+This runs `lint`, `typecheck`, `format:check`, `test:ci`, and `build` in
+sequence. Expected: every step passes. The `build` step will invoke the prebuild
+placeholder generator — it should succeed with no missing-image errors (this
+work does not touch any image).
+
+- [ ] **Step 2: Push develop**
+
+Run: `git push`
+
+Expected: the three new commits (Task 1, Task 3, and any follow-up) are pushed
+to `origin/develop`. They will auto-attach to the existing PR #55.
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage.** Problem (1) empty space / cramped chips → Task 3 moves
+  chips+CTA into a full-width row. Problem (2) hover mismatch → Task 3 adds the
+  hover-bg sibling and title color-flip. "Whole card clickable" → Task 3 wraps
+  the title in `ViewTransitionLink` with the absolute hit-area span. "Drop
+  redundant link" → Task 3 deletes the trailing `ViewTransitionLink` and Task 2
+  adds a regression test. Description copy → Task 1. All covered.
+- **Placeholder scan.** No TBDs, no "add error handling", no skipped code
+  blocks. Each step shows either exact file content or an exact command.
+- **Type consistency.** `ViewTransitionLink`, `ProjectImage`, and `Project` are
+  imported with the same names used today. The new test file uses
+  `querySelector("a")` on the `<h3>` to find the title link — matches the fact
+  that `ViewTransitionLink` is mocked as a plain `<a>` in the test's `vi.mock`.
+- **Risk the spec flagged.** "Forgetting to bump Visit-site above the title
+  hit-area span." Task 2 encodes this implicitly via the two-link count
+  assertion and the distinct-href assertion, and Task 4 step 2.5 exercises it
+  manually.

--- a/docs/superpowers/specs/2026-04-23-featured-hero-card-refinement-design.md
+++ b/docs/superpowers/specs/2026-04-23-featured-hero-card-refinement-design.md
@@ -1,0 +1,216 @@
+# Featured Hero Project Card Refinement
+
+**Date:** 2026-04-23 **Status:** Design approved, pending implementation plan
+
+## Problem
+
+Two issues with `FeaturedHeroProject` on the home page:
+
+1. **Layout.** The image sits in a 2/5 column and the
+   title/tagline/description/stack/CTAs are all stacked in the 3/5 column.
+   Because the right column's content is shorter than the image on most
+   viewports, there is visible empty space under the image. Stack chips and CTAs
+   are cramped in the right column even though they could use the full card
+   width.
+2. **Hover affordance mismatch.** The grid project cards (`Projects.tsx`) have a
+   hover background that extends beyond the parent's padding via an
+   absolutely-positioned sibling
+   (`absolute -inset-x-4 -inset-y-4 ... lg:-inset-x-6 ... lg:group-hover:bg-slate-800/50 ...`).
+   The hero card's hover is contained to the `<section>` (just a
+   `hover:bg-slate-800/30` on the element itself), so the two styles feel
+   inconsistent side-by-side.
+
+A secondary goal: make the whole card clickable to the project detail page so
+the hover affordance has a matching action. Today the title and a trailing "View
+TailorSift project" link both navigate there, and the hover effect decorates the
+card but doesn't actually make it clickable.
+
+## Approach
+
+Two small changes to `FeaturedHeroProject.tsx`, no data or prop changes:
+
+1. **Restructure into two rows.**
+   - Top row (current grid): image left (2/5), title + tagline + description
+     right (3/5).
+   - Bottom row (new, full card width): stack chips on the left, single "Visit
+     site" CTA on the right, same line via `flex items-center justify-between`.
+2. **Match grid-card hover behavior** by adding the same absolutely-positioned
+   hover-bg sibling the grid cards use. Make the title the primary link and
+   extend its hit area to cover the entire card using the existing
+   `span.absolute.-inset-*` trick already present in `Projects.tsx`. Drop the
+   redundant "View <title> project" link.
+
+**Why a full-width footer row, not just moving chips out:** the chips and the
+CTA read as "meta" to the project summary above. Grouping them on one line under
+the two-column header block gives the card a clearer hierarchy (visual → summary
+→ meta/action) and uses space the image was already reserving.
+
+**Why mirror the grid card's hover pattern rather than invent a new one:** the
+hero sits immediately above the grid cards on the home page. They should feel
+like the same family — same hover extension, same title color-flip, same
+overlay-link pattern.
+
+## Components
+
+### `FeaturedHeroProject.tsx` (modified)
+
+**Markup sketch (Tailwind classes elided where identical to today):**
+
+```tsx
+<section className="group relative mb-12 ..." aria-labelledby={...}>
+  {/* hover-bg sibling — identical to the one in Projects.tsx */}
+  <div className="absolute -inset-x-4 -inset-y-4 z-0 hidden rounded-md transition motion-reduce:transition-none lg:-inset-x-6 lg:block lg:group-hover:bg-slate-800/50 lg:group-hover:shadow-[inset_0_1px_0_0_rgba(148,163,184,0.1)] lg:group-hover:drop-shadow-lg" />
+
+  {/* Top row: image + summary */}
+  <div className="relative z-10 grid gap-6 sm:grid-cols-5 sm:gap-8">
+    <div className="sm:col-span-2" style={{ viewTransitionName: `project-image-${slug}` }}>
+      <ProjectImage … />
+    </div>
+    <div className="sm:col-span-3">
+      <h3 id={...}>
+        <ViewTransitionLink href={`/project/${slug}`} className="group/link ...hover:text-sky-400...">
+          <span className="absolute -inset-x-4 -inset-y-4 hidden rounded-md lg:-inset-x-6 lg:block" />
+          <span style={{ viewTransitionName: `project-title-${slug}` }}>{project.title}</span>
+        </ViewTransitionLink>
+      </h3>
+      <p className="…sky-400">Sift the roles. Tailor the approach.</p>
+      <p className="…slate-400">{project.description}</p>
+    </div>
+  </div>
+
+  {/* Bottom row: chips + CTA, full card width */}
+  <div className="relative z-10 mt-5 flex flex-wrap items-center justify-between gap-4">
+    <ul className="flex flex-wrap gap-2">
+      {project.stack?.map(…)}
+    </ul>
+    <a
+      href={project.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="relative z-20 inline-flex items-center gap-1 rounded-md bg-sky-400/10 px-3 py-1.5 text-sm font-medium text-sky-400 transition hover:bg-sky-400/20"
+      aria-label={`Visit ${project.title} live site (opens in new tab)`}
+    >
+      Visit site <ArrowUpRight className="h-4 w-4" />
+    </a>
+  </div>
+</section>
+```
+
+**Key points:**
+
+- The hover-bg sibling is `z-0`. Content rows are `relative z-10`. The external
+  "Visit site" anchor is `z-20` so it stays above the title link's invisible
+  hit-area span and remains independently clickable.
+- The "View TailorSift project" `ViewTransitionLink` is removed. The title
+  `ViewTransitionLink` replaces it as the sole route link; its `span.absolute`
+  extends the hit area to the whole card (including under the image and chips
+  row).
+- The title link gains `hover:text-sky-400 focus-visible:text-sky-400`
+  (currently absent) to match the grid cards' color-flip behavior.
+- Stack chips list keeps the existing pill styling; the only change is that it
+  lives in the bottom row's flex container.
+- The `ring-1 ring-sky-400/20` on the `<section>` stays — it's the resting-state
+  "this is the featured one" distinction. Only `hover:bg-slate-800/30` is
+  removed (superseded by the extended hover-bg sibling).
+
+### `tailorsift.ts` (data change, bundled with the layout work in the same implementation)
+
+Replace the `description` string:
+
+```ts
+description: "AI-powered job hunt platform that helps individuals sift roles and tailor CVs, cover letters, and interview prep to each opportunity.",
+```
+
+This is the only data edit. No schema changes.
+
+## Responsive behavior
+
+- `sm` and up: two-column top row, single-line bottom row with chips-left /
+  button-right via `justify-between`. If chips overflow the available width they
+  wrap within their `flex flex-wrap` container and the CTA stays on the right;
+  if the combined row still cannot fit, `flex-wrap` on the outer container drops
+  the CTA to its own line below the chips.
+- Below `sm`: top row collapses to a single column (image on top, text below,
+  same as today). Bottom row stays as `flex flex-wrap justify-between` — chips
+  start on one line, button wraps to its own line if needed.
+- The extended hover-bg sibling is already gated with `lg:block` in the grid
+  cards; we mirror that. Below `lg` there is no extended-hover affordance, which
+  is consistent with the rest of the page.
+
+## Accessibility
+
+- Title link is the primary, semantic route anchor. The full-card hit area is
+  added via a visually-hidden absolutely-positioned `<span>` inside that anchor
+  — no JS click handlers on the container.
+- `aria-labelledby` on the `<section>` continues to point at the title id
+  (unchanged).
+- The external "Visit site" link keeps its `aria-label` and remains
+  keyboard-focusable; it is a separate tab stop from the title link.
+- Removing "View TailorSift project" loses a text affordance but doesn't lose a
+  route (same destination as the title). The title itself reads as a link
+  (underline-on-hover via the color flip) and the hover bg reinforces
+  clickability on pointer devices.
+
+## Testing
+
+**Unit test updates** — `FeaturedHeroProject.test.tsx`:
+
+- Assert the title renders as a link to `/project/<slug>` (existing assertion
+  likely stays).
+- Assert "Visit site" anchor points at `project.url` with `target="_blank"`.
+- Assert the "View <title> project" text link is **not** present (guards against
+  regression).
+- Assert stack chips render in the footer row (query by role/text, not DOM
+  position).
+
+**Manual verification:**
+
+1. `pnpm dev`, visit `/`. Hover the hero card on `≥lg`: bg extends beyond card
+   padding, title flips to sky-400, whole card area is clickable.
+2. Click the image, the description gap, or the title: all land on
+   `/project/tailorsift`.
+3. Click "Visit site": opens `tailorsift.io` in a new tab; page underneath
+   unchanged.
+4. Narrow viewport: chips + CTA stay on one line when they fit; wrap gracefully
+   when they don't.
+5. Keyboard: `Tab` gives two stops — title link, then "Visit site". Both have
+   visible focus rings.
+6. Tailorsift card renders the new description on `/` (hero) and
+   `/project/tailorsift` (detail).
+
+**Explicitly out of scope:**
+
+- Refactoring the shared hover-bg markup into a reusable component. Two call
+  sites is below the threshold; revisit if a third hero variant appears.
+- Changing the grid cards (`Projects.tsx`) — they already work as designed.
+- Animation timing / easing changes.
+- Changes to the hero tagline (`"Sift the roles. Tailor the approach."`); still
+  hardcoded in the component per current design.
+
+## Risks & scope guardrails
+
+- **Nested-link regressions.** The existing grid cards already use this overlay
+  pattern, so the z-index layering is known to work in this codebase. Main risk
+  is forgetting to bump the "Visit site" anchor above the title's hit-area span
+  — covered by a manual click test and a unit test that checks both links route
+  to distinct URLs.
+- **View transitions.** The `viewTransitionName` on the title's inner span and
+  on the image container are preserved verbatim. Moving the chip/CTA block out
+  of the right column does not touch any node with a view transition name.
+- **Out of scope:** revisiting the hero tagline, extending this layout to
+  non-hero featured projects, animation changes, introducing a card-wide focus
+  ring.
+
+## Success criteria
+
+- No empty space under the image on the hero card; chips and "Visit site" occupy
+  the full card width on one line where they fit.
+- Hovering the hero card on `≥lg` produces the same bg-extension effect as the
+  grid cards, and the title color-flips to sky-400.
+- Clicking anywhere on the card (outside the "Visit site" button) navigates to
+  `/project/tailorsift`.
+- "Visit site" still opens `tailorsift.io` externally; no regression.
+- Tailorsift description reads as specified on both the home hero and the
+  project detail page.
+- Unit tests for `FeaturedHeroProject` pass; no console errors or Next.js
+  warnings.

--- a/src/data/projects/tailorsift.ts
+++ b/src/data/projects/tailorsift.ts
@@ -8,7 +8,7 @@ export const tailorsift: Project = {
 	featured: true,
 	hero: true,
 	description:
-		"AI-powered job hunt platform that sifts roles and tailors CVs, cover letters, and interview prep to each listing.",
+		"AI-powered job hunt platform that helps individuals sift roles and tailor CVs, cover letters, and interview prep to each opportunity.",
 	longDescription: `
 		<p>TailorSift helps job hunters turn generic applications into role-specific, polished materials in minutes. Users submit a job listing URL and the platform automatically extracts the role details, scores candidate-job fit, identifies skill gaps, and generates tailored CVs, cover letters, and interview prep grounded in the specific company and position.</p>
 		<p>The landing page is live at tailorsift.io with a waitlist, while the SaaS app is under active development. It operates on a freemium model with Free and Pro tiers, and supports multiple professional profiles so users can maintain distinct narratives for different career tracks.</p>

--- a/src/features/front/projects/components/FeaturedHeroProject.test.tsx
+++ b/src/features/front/projects/components/FeaturedHeroProject.test.tsx
@@ -86,10 +86,7 @@ describe("FeaturedHeroProject", () => {
 
 	it("links the title to the project detail page", () => {
 		render(<FeaturedHeroProject project={project} />);
-		const titleLink = screen
-			.getByRole("heading", { level: 3, name: /tailorsift/i })
-			.querySelector("a");
-		expect(titleLink).not.toBeNull();
+		const titleLink = screen.getByRole("link", { name: /^tailorsift$/i });
 		expect(titleLink).toHaveAttribute("href", "/project/tailorsift");
 	});
 
@@ -106,5 +103,17 @@ describe("FeaturedHeroProject", () => {
 		expect(links).toHaveLength(2);
 		const hrefs = links.map((l) => l.getAttribute("href")).sort();
 		expect(hrefs).toEqual(["/project/tailorsift", "https://tailorsift.io"]);
+	});
+
+	it("places the title link's full-card hit area in a wrapper that also contains the chips+CTA row", () => {
+		render(<FeaturedHeroProject project={project} />);
+		const titleLink = screen.getByRole("link", { name: /^tailorsift$/i });
+		// The wrapper containing both rows is the link's closest `.relative` ancestor — it must also contain the Visit site anchor.
+		const wrapper = titleLink.closest("div.relative");
+		expect(wrapper).not.toBeNull();
+		const visitLink = screen.getByRole("link", {
+			name: /visit tailorsift live site/i,
+		});
+		expect(wrapper).toContainElement(visitLink);
 	});
 });

--- a/src/features/front/projects/components/FeaturedHeroProject.test.tsx
+++ b/src/features/front/projects/components/FeaturedHeroProject.test.tsx
@@ -84,9 +84,27 @@ describe("FeaturedHeroProject", () => {
 		expect(link).toHaveAttribute("rel", "noopener noreferrer");
 	});
 
-	it("renders project detail link with descriptive text", () => {
+	it("links the title to the project detail page", () => {
 		render(<FeaturedHeroProject project={project} />);
-		const link = screen.getByRole("link", { name: /view tailorsift project/i });
-		expect(link).toHaveAttribute("href", "/project/tailorsift");
+		const titleLink = screen
+			.getByRole("heading", { level: 3, name: /tailorsift/i })
+			.querySelector("a");
+		expect(titleLink).not.toBeNull();
+		expect(titleLink).toHaveAttribute("href", "/project/tailorsift");
+	});
+
+	it('does not render the removed "View <title> project" link', () => {
+		render(<FeaturedHeroProject project={project} />);
+		expect(
+			screen.queryByRole("link", { name: /view tailorsift project/i })
+		).not.toBeInTheDocument();
+	});
+
+	it("renders exactly two links: the title link and the Visit site link", () => {
+		render(<FeaturedHeroProject project={project} />);
+		const links = screen.getAllByRole("link");
+		expect(links).toHaveLength(2);
+		const hrefs = links.map((l) => l.getAttribute("href")).sort();
+		expect(hrefs).toEqual(["/project/tailorsift", "https://tailorsift.io"]);
 	});
 });

--- a/src/features/front/projects/components/FeaturedHeroProject.tsx
+++ b/src/features/front/projects/components/FeaturedHeroProject.tsx
@@ -10,10 +10,12 @@ interface FeaturedHeroProjectProps {
 export const FeaturedHeroProject = ({ project }: FeaturedHeroProjectProps) => {
 	return (
 		<section
-			className="group relative mb-12 rounded-lg p-5 ring-1 ring-sky-400/20 transition hover:bg-slate-800/30 md:p-6"
+			className="group relative mb-12 rounded-lg p-5 ring-1 ring-sky-400/20 transition md:p-6"
 			aria-labelledby={`hero-project-${project.slug}-title`}
 		>
-			<div className="grid gap-6 sm:grid-cols-5 sm:gap-8">
+			<div className="absolute -inset-x-4 -inset-y-4 z-0 hidden rounded-md transition motion-reduce:transition-none lg:-inset-x-6 lg:block lg:group-hover:bg-slate-800/50 lg:group-hover:shadow-[inset_0_1px_0_0_rgba(148,163,184,0.1)] lg:group-hover:drop-shadow-lg" />
+
+			<div className="relative z-10 grid gap-6 sm:grid-cols-5 sm:gap-8">
 				<div
 					className="sm:col-span-2"
 					style={{ viewTransitionName: `project-image-${project.slug}` }}
@@ -30,9 +32,21 @@ export const FeaturedHeroProject = ({ project }: FeaturedHeroProjectProps) => {
 					<h3
 						id={`hero-project-${project.slug}-title`}
 						className="text-xl font-semibold text-slate-200"
-						style={{ viewTransitionName: `project-title-${project.slug}` }}
 					>
-						{project.title}
+						<ViewTransitionLink
+							href={`/project/${project.slug}`}
+							className="group/link inline-flex items-baseline text-slate-200 transition hover:text-sky-400 focus-visible:text-sky-400"
+						>
+							<span className="absolute -inset-x-4 -inset-y-4 hidden rounded-md lg:-inset-x-6 lg:block" />
+							<span
+								className="inline-block"
+								style={{
+									viewTransitionName: `project-title-${project.slug}`,
+								}}
+							>
+								{project.title}
+							</span>
+						</ViewTransitionLink>
 					</h3>
 					<p className="mt-1 text-sm font-medium text-sky-400">
 						Sift the roles. Tailor the approach.
@@ -40,36 +54,31 @@ export const FeaturedHeroProject = ({ project }: FeaturedHeroProjectProps) => {
 					<p className="mt-3 text-sm leading-normal text-slate-400">
 						{project.description}
 					</p>
-					{project.stack && (
-						<ul className="mt-3 flex flex-wrap">
-							{project.stack.map((stackName) => (
-								<li key={stackName} className="mr-1.5 mt-2">
-									<div className="flex items-center rounded-full bg-sky-400/10 px-3 py-1 text-xs font-medium leading-5 text-sky-400">
-										{stackName}
-									</div>
-								</li>
-							))}
-						</ul>
-					)}
-					<div className="mt-5 flex flex-wrap items-center gap-4">
-						<a
-							href={project.url}
-							target="_blank"
-							rel="noopener noreferrer"
-							aria-label={`Visit ${project.title} live site (opens in new tab)`}
-							className="inline-flex items-center gap-1 rounded-md bg-sky-400/10 px-3 py-1.5 text-sm font-medium text-sky-400 transition hover:bg-sky-400/20"
-						>
-							Visit site
-							<ArrowUpRight className="h-4 w-4" />
-						</a>
-						<ViewTransitionLink
-							href={`/project/${project.slug}`}
-							className="text-sm font-medium text-slate-200 underline decoration-slate-500 underline-offset-4 transition hover:text-sky-400 hover:decoration-sky-400"
-						>
-							View {project.title} project
-						</ViewTransitionLink>
-					</div>
 				</div>
+			</div>
+
+			<div className="relative z-10 mt-5 flex flex-wrap items-center justify-between gap-4">
+				{project.stack && (
+					<ul className="flex flex-wrap gap-2">
+						{project.stack.map((stackName) => (
+							<li key={stackName}>
+								<div className="flex items-center rounded-full bg-sky-400/10 px-3 py-1 text-xs font-medium leading-5 text-sky-400">
+									{stackName}
+								</div>
+							</li>
+						))}
+					</ul>
+				)}
+				<a
+					href={project.url}
+					target="_blank"
+					rel="noopener noreferrer"
+					aria-label={`Visit ${project.title} live site (opens in new tab)`}
+					className="relative z-20 inline-flex items-center gap-1 rounded-md bg-sky-400/10 px-3 py-1.5 text-sm font-medium text-sky-400 transition hover:bg-sky-400/20"
+				>
+					Visit site
+					<ArrowUpRight className="h-4 w-4" />
+				</a>
 			</div>
 		</section>
 	);

--- a/src/features/front/projects/components/FeaturedHeroProject.tsx
+++ b/src/features/front/projects/components/FeaturedHeroProject.tsx
@@ -15,70 +15,72 @@ export const FeaturedHeroProject = ({ project }: FeaturedHeroProjectProps) => {
 		>
 			<div className="absolute -inset-x-4 -inset-y-4 z-0 hidden rounded-md transition motion-reduce:transition-none lg:-inset-x-6 lg:block lg:group-hover:bg-slate-800/50 lg:group-hover:shadow-[inset_0_1px_0_0_rgba(148,163,184,0.1)] lg:group-hover:drop-shadow-lg" />
 
-			<div className="relative z-10 grid gap-6 sm:grid-cols-5 sm:gap-8">
-				<div
-					className="sm:col-span-2"
-					style={{ viewTransitionName: `project-image-${project.slug}` }}
-				>
-					<ProjectImage
-						src={project.image}
-						alt={`Screenshot of ${project.title} - ${project.description.slice(0, 100)}`}
-						width={400}
-						height={250}
-						className="w-full rounded border-2 border-slate-200/10 transition group-hover:border-slate-200/30"
-					/>
-				</div>
-				<div className="sm:col-span-3">
-					<h3
-						id={`hero-project-${project.slug}-title`}
-						className="text-xl font-semibold text-slate-200"
+			<div className="relative z-10">
+				<div className="grid gap-6 sm:grid-cols-5 sm:gap-8">
+					<div
+						className="sm:col-span-2"
+						style={{ viewTransitionName: `project-image-${project.slug}` }}
 					>
-						<ViewTransitionLink
-							href={`/project/${project.slug}`}
-							className="group/link inline-flex items-baseline text-slate-200 transition hover:text-sky-400 focus-visible:text-sky-400"
+						<ProjectImage
+							src={project.image}
+							alt={`Screenshot of ${project.title} - ${project.description.slice(0, 100)}`}
+							width={400}
+							height={250}
+							className="w-full rounded border-2 border-slate-200/10 transition group-hover:border-slate-200/30"
+						/>
+					</div>
+					<div className="sm:col-span-3">
+						<h3
+							id={`hero-project-${project.slug}-title`}
+							className="text-xl font-semibold text-slate-200"
 						>
-							<span className="absolute -inset-x-4 -inset-y-4 hidden rounded-md lg:-inset-x-6 lg:block" />
-							<span
-								className="inline-block"
-								style={{
-									viewTransitionName: `project-title-${project.slug}`,
-								}}
+							<ViewTransitionLink
+								href={`/project/${project.slug}`}
+								className="inline-flex items-baseline text-slate-200 transition hover:text-sky-400 focus-visible:text-sky-400"
 							>
-								{project.title}
-							</span>
-						</ViewTransitionLink>
-					</h3>
-					<p className="mt-1 text-sm font-medium text-sky-400">
-						Sift the roles. Tailor the approach.
-					</p>
-					<p className="mt-3 text-sm leading-normal text-slate-400">
-						{project.description}
-					</p>
+								<span className="absolute -inset-x-4 -inset-y-4 hidden rounded-md lg:-inset-x-6 lg:block" />
+								<span
+									className="inline-block"
+									style={{
+										viewTransitionName: `project-title-${project.slug}`,
+									}}
+								>
+									{project.title}
+								</span>
+							</ViewTransitionLink>
+						</h3>
+						<p className="mt-1 text-sm font-medium text-sky-400">
+							Sift the roles. Tailor the approach.
+						</p>
+						<p className="mt-3 text-sm leading-normal text-slate-400">
+							{project.description}
+						</p>
+					</div>
 				</div>
-			</div>
 
-			<div className="relative z-10 mt-5 flex flex-wrap items-center justify-between gap-4">
-				{project.stack && (
-					<ul className="flex flex-wrap gap-2">
-						{project.stack.map((stackName) => (
-							<li key={stackName}>
-								<div className="flex items-center rounded-full bg-sky-400/10 px-3 py-1 text-xs font-medium leading-5 text-sky-400">
-									{stackName}
-								</div>
-							</li>
-						))}
-					</ul>
-				)}
-				<a
-					href={project.url}
-					target="_blank"
-					rel="noopener noreferrer"
-					aria-label={`Visit ${project.title} live site (opens in new tab)`}
-					className="relative z-20 inline-flex items-center gap-1 rounded-md bg-sky-400/10 px-3 py-1.5 text-sm font-medium text-sky-400 transition hover:bg-sky-400/20"
-				>
-					Visit site
-					<ArrowUpRight className="h-4 w-4" />
-				</a>
+				<div className="mt-5 flex flex-wrap items-center justify-between gap-4">
+					{project.stack && (
+						<ul className="flex flex-wrap gap-2">
+							{project.stack.map((stackName) => (
+								<li key={stackName}>
+									<div className="flex items-center rounded-full bg-sky-400/10 px-3 py-1 text-xs font-medium leading-5 text-sky-400">
+										{stackName}
+									</div>
+								</li>
+							))}
+						</ul>
+					)}
+					<a
+						href={project.url}
+						target="_blank"
+						rel="noopener noreferrer"
+						aria-label={`Visit ${project.title} live site (opens in new tab)`}
+						className="relative z-20 inline-flex items-center gap-1 rounded-md bg-sky-400/10 px-3 py-1.5 text-sm font-medium text-sky-400 transition hover:bg-sky-400/20"
+					>
+						Visit site
+						<ArrowUpRight className="h-4 w-4" />
+					</a>
+				</div>
 			</div>
 		</section>
 	);


### PR DESCRIPTION
## Summary

Refines the `FeaturedHeroProject` card on the home page and updates the Tailorsift description.

**Layout**
- Two-row structure: image + title/tagline/description on top, stack chips and "Visit site" on a full-width bottom row (one line, `justify-between`).
- Removes the redundant "View TailorSift project" text link; the title is now the sole route anchor.
- Whole card is clickable → `/project/tailorsift`. "Visit site" remains an independent click target for the external URL.

**Hover**
- Matches the grid project cards: adds the same extended hover-bg sibling (`lg:group-hover:bg-slate-800/50` + inset shadow) that renders outside the card padding on `≥lg`.
- Title flips to sky-400 on hover/focus-visible, consistent with grid card titles.

**Copy**
- Tailorsift `description` → "AI-powered job hunt platform that helps individuals sift roles and tailor CVs, cover letters, and interview prep to each opportunity."

**Bug caught in review**
- Initial implementation had the hit-area span contained by only the top row's `relative` wrapper, so clicks on the chips row didn't propagate. Fixed by collapsing both rows into a single `relative z-10` wrapper; regression test encodes the containing-block requirement.

Spec/plan:
- `docs/superpowers/specs/2026-04-23-featured-hero-card-refinement-design.md`
- `docs/superpowers/plans/2026-04-23-featured-hero-card-refinement.md`

## Test plan
- [x] `pnpm validate` passes (lint, typecheck, format:check, tests 10/10, build)
- [ ] On `/` at ≥lg: hover extends beyond card padding; title turns sky-400
- [ ] Click chips row / empty space below description → navigates to `/project/tailorsift`
- [ ] Click "Visit site" → opens tailorsift.io in new tab, home page unchanged
- [ ] Narrow viewport: chips + CTA wrap cleanly, no horizontal scrollbar
- [ ] New description reads correctly on `/` and `/project/tailorsift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)